### PR TITLE
Add CONTRIBUTING.md guidelines to the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing to X-Road Metrics
+
+The X-Road Metrics extension project follows the same general guidelines that the core X-Road project uses, please
+follow [this link](https://github.com/nordic-institute/X-Road/blob/develop/CONTRIBUTING.md) to learn about them.


### PR DESCRIPTION
Add CONTRIBUTING.md guidelines to the repository, linking it to the core X-Road repository guidelines.