### PR TITLE
Fix duplicate logging

### DIFF
--- a/opendata_module/opmon_opendata/logger_manager.py
+++ b/opendata_module/opmon_opendata/logger_manager.py
@@ -58,7 +58,7 @@ class LoggerManager:
 
     def _handler_is_set(self, handlers):
         for handler in handlers:
-            if handler is WatchedFileHandler and os.path.abspath(self.log_path) == handler.baseFilename:
+            if isinstance(handler, WatchedFileHandler) and os.path.abspath(self.log_path) == handler.baseFilename:
                 return True
         return False
 


### PR DESCRIPTION
Currently check `handler is WatchedFileHandler` always fails and a new handler is added before every write to the log. First log line gets logged once, second line twice, tenth line ten times and so on.

The proposed fix is to use `isinstance(handler, WatchedFileHandler)`.

For example:
```
python3
Python 3.8.10 (default, Jun 22 2022, 20:18:18)
>>> from logging.handlers import WatchedFileHandler
>>> handler = WatchedFileHandler('/tmp/log')
>>> handler is WatchedFileHandler
False
>>> isinstance(handler, WatchedFileHandler)
True
```