### PR TITLE
Save collected logs to files

### DIFF
--- a/collector_module/etc/settings.yaml
+++ b/collector_module/etc/settings.yaml
@@ -41,6 +41,24 @@ collector:
   # Only one collector instance can be running at a time.
   pid-directory: /var/run/xroad-metrics/collector
 
+  # Write collected documents to files in addition to database if documents-log-directory is provided and not empty.
+  # Make sure this directory is writable by xroad-metrics user.
+  # Collector will create subdirectories "<Instance>/<Year>/<Month>/Day" for logs collected during that day.
+  # Collector will not automatically remove older logs.
+  # documents-log-directory: /var/lib/collector
+  documents-log-directory:
+
+  # If document writing to files is enabled then python RotatingFileHandler is used to write documents to log files.
+  # documents-log-file-size (RotatingFileHandler maxBytes parameter) sets maximum allowed file size in bytes.
+  # documents-log-max-files (RotatingFileHandler backupCount parameter) sets maximum count of log backup files.
+  # Rotated files will have a suffix ".<n>".
+  # Limits are applied separately for each server, because every server has its own log file.
+  # If log file size and count limiting is not required then set both parameters to "0" to disable log rotation.
+  # documents-log-file-size: 100000000
+  # documents-log-max-files: 100
+  documents-log-file-size: 0
+  documents-log-max-files: 0
+
 xroad:
   instance: <FILL>
 

--- a/collector_module/opmon_collector/collector_worker.py
+++ b/collector_module/opmon_collector/collector_worker.py
@@ -21,6 +21,10 @@
 #  THE SOFTWARE.
 
 import json
+import logging
+from logging.handlers import RotatingFileHandler
+import datetime
+import os
 import multiprocessing
 import re
 import uuid
@@ -50,10 +54,12 @@ class CollectorWorker:
         self.records = []
 
     def work(self):
-        for _ in range(self.settings['collector']['repeat-limit']):
+        for repeat in range(self.settings['collector']['repeat-limit']):
             try:
                 response = self._request_opmon_data()
                 self.records = self._parse_attachment(response)
+                if self.settings['collector'].get('documents-log-directory', ''):
+                    self._store_records_to_file(repeat)
                 self._store_records_to_database()
                 self.batch_start = self._parse_next_records_from_response(response) or self.batch_end
                 self.server_m.set_next_records_timestamp(self.server_key, self.batch_start)
@@ -137,6 +143,32 @@ class CollectorWorker:
         except Exception as e:
             self.log_warn("Cannot parse response attachment.", '')
             raise e
+
+    def _store_records_to_file(self, repeat):
+        if len(self.records):
+            host_name = re.sub("[^0-9a-zA-Z.-]+", '.', self.server_data['server'])
+
+            now = datetime.datetime.now()
+            log_path = f"{self.settings['collector']['documents-log-directory']}" \
+                       f"/{self.settings['xroad']['instance']}/{now.year:04d}/{now.month:02d}/{now.day:02d}/"
+
+            if not os.path.exists(log_path):
+                os.makedirs(log_path)
+
+            self.log_info(f"Appending {len(self.records)} documents to log file.")
+            records_logger = logging.getLogger(host_name)
+            records_logger.setLevel(logging.INFO)
+            # Adding handler only if this is not a repeated query to the host
+            if repeat == 0:
+                handler = RotatingFileHandler(
+                    log_path + host_name + ".log",
+                    maxBytes=self.settings['collector'].get('documents-log-file-size', 0),
+                    backupCount=self.settings['collector'].get('documents-log-max-files', 0))
+                records_logger.addHandler(handler)
+            for record in self.records:
+                records_logger.info(json.dumps(record, separators=(',', ':')))
+        else:
+            self.log_warn("No documents to append to log file!", "")
 
     def _store_records_to_database(self):
         if len(self.records):


### PR DESCRIPTION
* Adding configurable support to save collected logs to files
* Adding configuration examples

Currently collector saves logs into database, and if you need to backup collected data as files, then a separate collector software is required. In order to simplify setup and avoid duplicate collector queries it is useful to be able to save collected data to files in addition to database.