### PR TITLE
Opmondev-150: make TLS connection to PostgreSQL from db clients available

### DIFF
--- a/anonymizer_module/etc/settings.yaml
+++ b/anonymizer_module/etc/settings.yaml
@@ -83,6 +83,8 @@ postgres:
   database-name: <FILL>
   table-name: logs
   buffer-size: 10000
+  ssl-mode:
+  ssl-root-cert:
   readonly-users:
     - <FILL>
     - <FILL>

--- a/anonymizer_module/opmon_anonymizer/iio/postgresql_manager.py
+++ b/anonymizer_module/opmon_anonymizer/iio/postgresql_manager.py
@@ -33,6 +33,10 @@ class PostgreSqlManager(object):
         self._table_name = postgres_settings['table-name']
         self._readonly_users = postgres_settings['readonly-users']
         self._connection_string = self._get_connection_string()
+        self._connect_args = {
+            'sslmode': postgres_settings.get('ssl-mode'),
+            'sslrootcert': postgres_settings.get('ssl-root-cert')
+        }
 
         self._field_order = [field_name for field_name, _ in table_schema]
         if table_schema:
@@ -48,7 +52,7 @@ class PostgreSqlManager(object):
             for datum in data:
                 datum['requestInDate'] = datetime.fromtimestamp(datum['requestInTs'] / 1000).strftime('%Y-%m-%d')
 
-            with pg.connect(self._connection_string) as connection:
+            with pg.connect(self._connection_string, **self._connect_args) as connection:
                 cursor = connection.cursor()
                 query = self._generate_insert_query(cursor, data)
                 cursor.execute(query)
@@ -73,7 +77,7 @@ class PostgreSqlManager(object):
 
     def is_alive(self):
         try:
-            with pg.connect(self._connection_string) as connection:
+            with pg.connect(self._connection_string, **self._connect_args) as connection:
                 pass
             return True
 
@@ -86,7 +90,7 @@ class PostgreSqlManager(object):
 
     def _ensure_table(self, schema, index_columns):
         try:
-            with pg.connect(self._connection_string) as connection:
+            with pg.connect(self._connection_string, **self._connect_args) as connection:
                 cursor = connection.cursor()
                 if not self._table_exists(cursor):
                     self._create_table(cursor, schema, index_columns)
@@ -121,7 +125,7 @@ class PostgreSqlManager(object):
 
     def _ensure_privileges(self):
         try:
-            with pg.connect(self._connection_string) as connection:
+            with pg.connect(self._connection_string, **self._connect_args) as connection:
                 cursor = connection.cursor()
 
                 for readonly_user in self._readonly_users:

--- a/docs/anonymizer_module.md
+++ b/docs/anonymizer_module.md
@@ -11,21 +11,21 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 
 ## About
 
-The **Anonymizer module** is part of [X-Road Metrics](../README.md), 
+The **Anonymizer module** is part of [X-Road Metrics](../README.md),
 which include following modules:
  - [Database module](../database_module.md)
  - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md) 
- - [Reports module](../reports_module.md) 
+ - [Corrector module](../corrector_module.md)
+ - [Reports module](../reports_module.md)
  - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md) 
+ - [Opendata module](../opendata_module.md)
  - [Networking/Visualizer module](../networking_module.md)
 
-The **Anonymizer module** is responsible of preparing the operational monitoring data for publication through 
-the [Opendata module](opendata_module.md). Anonymizer configuration allows X-Road Metrics extension administrator to set 
+The **Anonymizer module** is responsible of preparing the operational monitoring data for publication through
+the [Opendata module](opendata_module.md). Anonymizer configuration allows X-Road Metrics extension administrator to set
 fine-grained rules for excluding whole operatinal monitoring data records or to modify selected data fields before the data is published.
 
-The anonymizer module uses the operational monitoring data that [Corrector module](corrector_module.md) has prepared and stored 
+The anonymizer module uses the operational monitoring data that [Corrector module](corrector_module.md) has prepared and stored
 to MongoDb as input. The anonymizer processes the data using the configured ruleset and stores the output to the
 opendata PostgreSQL database for publication.
 
@@ -46,10 +46,38 @@ run on a host that has access to both MongoDb and PostgreSQL.
 
 The anonymizer module provides no incoming network interfaces.
 
+## Database (PostgreSQL) setup
+
+See [Opendata database](opendata_module.md)
+
+### Establish encrypted SSL/TLS client connection
+
+For a connection to be known SSL-secured, SSL usage must be configured on both the client and the server before the connection is made.
+If it is only configured on the server, the client may end up sending sensitive information before it knows that the server requires high security.
+
+To ensure secure connections `ssl-mode` and `ssl-root-cert` parameterers has to be provided in settings file.
+Possible values for `ssl-mode`: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`
+For detailed information see https://www.postgresql.org/docs/current/libpq-ssl.html
+
+To configure path to the SSL root certificate, set `ssl-root-cert`
+
+Example of `/etc/settings.yaml` entry:
+```
+postgres:
+  host: localhost
+  port: 5432
+  user: postgres
+  password: *******
+  database-name: postgres
+  table-name: logs
+  ssl-mode: verify-full
+  ssl-root-cert: /etc/ssl/certs/root.crt
+```
+
 ## Installation
 
-This sections describes the necessary steps to install the **anonymizer module** on 
-an Ubuntu 20.04 Linux host. For a complete overview of different modules and machines, 
+This sections describes the necessary steps to install the **anonymizer module** on
+an Ubuntu 20.04 Linux host. For a complete overview of different modules and machines,
 please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
 
 
@@ -75,7 +103,7 @@ sudo apt-get install xroad-metrics-anonymizer
 The installation package automatically installs following items:
  * xroad-metrics-anonymizer command
  * Linux user named _xroad-metrics_ and group _xroad-metrics_
- * configuration files: 
+ * configuration files:
    * _/etc/xroad-metrics/anonymizer/settings.yaml_
    * _/etc/xroad-metrics/anonymizer/field_data.yaml_
    * _/etc/xroad-metrics/anonymizer/field_translations.yaml_
@@ -125,17 +153,17 @@ _settings.yaml_ file.
 A hiding rule consists of list of feature - regular expression pairs. If the contents of the field matches the regex,
 then the record is excluded from opendata set.
 
-A typical example is to exclude all operational monitoring data records related to specific clients, services or member types. 
-The example below defines two hiding rules. 
+A typical example is to exclude all operational monitoring data records related to specific clients, services or member types.
+The example below defines two hiding rules.
 First rule will exclude all records where client id is _"foo"_ **and** service id is _"bar"_.
 The second rule will exclude all records where service member class is not _"GOV"_.
 
 ```yaml
 # settings.yaml
 anonymizer:
-  
+
   ...
-  
+
   hiding-rules:
     -
       - feature: 'clientMemberCode'
@@ -149,7 +177,7 @@ anonymizer:
 ```
 
 ### Configuration of Substitution Rules
-Anonymizer can be configured to substitute the values of selected fields in the opendata set for 
+Anonymizer can be configured to substitute the values of selected fields in the opendata set for
 records that fulfill a set of conditions. These _substitution rules_ are defined in _settings.yaml_ file.
 
 A substitution rule has two parts. First *conditions* has a set of rules that defines the set of records
@@ -159,13 +187,13 @@ to be substituted and value contains the substitute string.
 
 The below example defines two substitution rules.
 First rule will substitute client and service member codes with _"N/A"_ if the client member code is _"foo2"_.
-The second rule will substitute message id with 0, if client member code is _"bar2"_ and 
+The second rule will substitute message id with 0, if client member code is _"bar2"_ and
 service member code is _"foo2"_.
 
 ```yaml
 # settings.yaml
 anonymizer:
-  
+
   ...
 
   substitution-rules:
@@ -191,8 +219,8 @@ anonymizer:
 ```
 
 ### Settings Profiles
-To run anonymizer for multiple X-Road instances, a settings profile for each instance can be created. 
-For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml` 
+To run anonymizer for multiple X-Road instances, a settings profile for each instance can be created.
+For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml`
 file named `settings_DEV.yaml`, `settings_TEST.yaml` and `settings_PROD.yaml`.
 Then fill the profile specific settings to each file and use the --profile
 flag when running xroad-metrics-anonymizer. For example to run anonymizer manually using the TEST profile:
@@ -214,13 +242,13 @@ sudo su xroad-metrics
 Currently following command line arguments are supported:
 ```bash
 xroad-metrics-anonymizer --help                     # Show description of the command line argumemts
-xroad-metrics-anonymizer --limit <number>           # Optional flag to limit the number of records to process. 
+xroad-metrics-anonymizer --limit <number>           # Optional flag to limit the number of records to process.
 xroad-metrics-anonymizer --profile <profile name>   # Run with a non-default settings profile
 ```
 
 
 ### Cron settings
-Default installation includes a cronjob in _/etc/cron.d/xroad-metrics-anonymizer-cron_ that runs anonymizer monthly. 
+Default installation includes a cronjob in _/etc/cron.d/xroad-metrics-anonymizer-cron_ that runs anonymizer monthly.
 This job runs anonymizer using default settings profile (_/etc/xroad-metrics/collector/settings.yaml_)
 
 If you want to change the collector cronjob scheduling or settings profiles, edit the file e.g. with vi
@@ -245,7 +273,7 @@ If collector is to be run only manually, comment out the default cron task:
 
 ## Monitoring and Status
 
-### Logging 
+### Logging
 
 The settings for the log file in the settings file are the following:
 
@@ -258,7 +286,7 @@ xroad:
 logger:
   name: anonymizer
   module: anonymizer
-  
+
   # Possible logging levels from least to most verbose are:
   # CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG
   level: INFO
@@ -269,11 +297,11 @@ logger:
 
 ```
 
-The log file is written to `log-path` and log file name contains the X-Road instance name. 
+The log file is written to `log-path` and log file name contains the X-Road instance name.
 The above example configuration would write logs to `/var/log/xroad-metrics/collector/logs/log_collector_EXAMPLE.json`.
 
 
-The **anonymizer module** log handler is compatible with the logrotate utility. 
+The **anonymizer module** log handler is compatible with the logrotate utility.
 To configure log rotation for the example setup above, create the file:
 
 ```
@@ -310,7 +338,7 @@ logger:
 
 ```
 
-The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name. 
+The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name.
 The above example configuration would write logs to
  `/var/log/xroad-metrics/anonymizer/heartbeat/heartbeat_anonymizer_EXAMPLE.json`.
 

--- a/docs/networking_module.md
+++ b/docs/networking_module.md
@@ -14,17 +14,17 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 The Networking module is part of [X-Road Metrics](../README.md). All other modules in X-Road Operational Monitoring are:
  - [Database module](../database_module.md)
  - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md) 
- - [Reports module](../reports_module.md) 
+ - [Corrector module](../corrector_module.md)
+ - [Reports module](../reports_module.md)
  - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md) 
+ - [Opendata module](../opendata_module.md)
  - [Networking/Visualizer module](../networking_module.md)
 
-The purpose of the **Networking module** is to visualize the networking activity between the X-Road members. 
+The purpose of the **Networking module** is to visualize the networking activity between the X-Road members.
 It consists of:
- 
-1. **Data preparation** R script that queries the Open data PostgreSQL database, 
-does relevant calculations (query counts between X-Road members) and writes a table file to be used in the 
+
+1. **Data preparation** R script that queries the Open data PostgreSQL database,
+does relevant calculations (query counts between X-Road members) and writes a table file to be used in the
 visualization web application;
 
 2. RStudio Shiny-based **web application** to visualize the networking activity between the X-Road members.
@@ -71,8 +71,8 @@ Note that the package does not install Shiny Server itself. See next chapter for
 Apache is used as a reverse proxy in front of Shiny Server to add SSL encryption.
 
 ### Install Shiny Server
-Shiny Server is an open source, free of charge webserver that serves web-apps written using the R-language Shiny 
-framework. The Networking module UI is a Shiny app and requires Shiny Server to run. 
+Shiny Server is an open source, free of charge webserver that serves web-apps written using the R-language Shiny
+framework. The Networking module UI is a Shiny app and requires Shiny Server to run.
 Shiny Server is developed and distributed by RStudio (https://rstudio.com/products/shiny/shiny-server/),
 and currently they don't provide an Ubuntu repository for it. Therefore, Shiny Server is not included as a dependency
 of the xroad-metrics-networking package installed above.
@@ -93,7 +93,7 @@ Default settings file for xroad-metrics-networking data preparation step is /etc
 Before running the data preparation, user should fill in the following configuration:
   - X-Road instance name
   - Open data PostgreSQL database connection configuration
-    
+
 Additionally, the following parameters can be adjusted in the settings file:
   - Time interval for data to be fetched from Open data PostgreSQL database
   - List of metaservices
@@ -108,8 +108,8 @@ Default location for this file is /etc/xroad-metrics/networking/riha.json
 TODO: solve riha.json handling: OPMONDEV-90, OPMONDEV-91
 
 ### Settings profiles
-The xroad-metrics-networking module supports displaying data for multiple X-Road instances via settings profiles. 
-For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml` 
+The xroad-metrics-networking module supports displaying data for multiple X-Road instances via settings profiles.
+For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml`
 file named `settings_DEV.yaml`, `settings_TEST.yaml` and `settings_PROD.yaml`.
 Then fill the profile specific settings to each file and use the --profile
 flag when running xroad-metrics-networking command. For example to run using the TEST profile:
@@ -125,13 +125,39 @@ the command should be represented in the following way:
 ```
 
 Now the xroad-metrics-networking data preparation program will get configuration settings from a settings file named
-settings_TEST.yaml. The command searches the settings file first in current working direcrtory, 
+settings_TEST.yaml. The command searches the settings file first in current working direcrtory,
 then in _/etc/xroad-metrics/networking/_. xroad-metrics-networking command will then tag the generated output files with the profile
 name (TEST in this case).
 
 In the UI you can view the data of different settings profiles by providing the *profile* query parameter.
 E.g. if the Shiny Server is running on host *myshiny* and port 3838 then you can view the data prepared using settings
 profile TEST by browsing to http://myshiny:3838?profile=TEST
+
+### Database (PostgreSQL) setup
+
+See [Opendata database](opendata_module.md)
+
+#### Establish encrypted SSL/TLS client connection
+
+For a connection to be known SSL-secured, SSL usage must be configured on both the client and the server before the connection is made.
+If it is only configured on the server, the client may end up sending sensitive information before it knows that the server requires high security.
+
+To ensure secure connections `ssl_mode` and `ssl_root_cert` parameterers has to be provided in settings file.
+Possible values for `ssl_mode`: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`
+For detailed information see https://www.postgresql.org/docs/current/libpq-ssl.html
+
+To configure path to the SSL root certificate, set `ssl_root_cert`
+
+Example of `/etc/settings.yaml` entry:
+```
+postgres:
+  host: localhost
+  port: 5432
+  user: postgres
+  password: *******
+  ssl_mode: verify-ca
+  ssl_root_cert: /etc/ssl/certs/root.crt
+```
 
 ### Apache Configuration
 #### Configuration of Production Certificates
@@ -156,7 +182,7 @@ If Networking and Opendata modules are on the same host, Apache configuration ne
 route traffic to each service. Simplest way is to set up two DNS names for the host and set configure
 one Apache virtual host for each module.
 
-So assume that the host has two DNS names: *xroad-metrics-networking.mydomain.org* and 
+So assume that the host has two DNS names: *xroad-metrics-networking.mydomain.org* and
 *xroad-metrics-opendata.mydomain.org* then you can simply change check that the domain names
 are set in Apache site configurations.
 
@@ -179,29 +205,29 @@ sudo systemctl restart apache2.service
 
 ## Data preparation script, overview
 
-The data preparation step can be started by the command `xroad-metrics-networking`. It does the following: 
+The data preparation step can be started by the command `xroad-metrics-networking`. It does the following:
 
 1. Read configuration parameters from a settings-file. Default settings-file is `/etc/xroad-metrics/networking/settings.yaml`.
-2. Read instance specific complementary files `/etc/xroad-metrics/networking/riha.json` 
+2. Read instance specific complementary files `/etc/xroad-metrics/networking/riha.json`
    in order to link `clientmembercode` and `servicemembercode` to the names of the X-Road members.
 3. Establishes a connection to Open data PostgreSQL and queries the most recent date in field `requestindate`.
-4. Queries the most recent data from Open data dating back to certain number of days 
-   ('interval' in settings file, default 30 days) from the most recent `requestindate`. 
+4. Queries the most recent data from Open data dating back to certain number of days
+   ('interval' in settings file, default 30 days) from the most recent `requestindate`.
    The script retrieves only `succeeded=True` logs. The script retrieves the following fields:
 
     ```
-    requestindate, clientmembercode, clientsubsystemcode, 
+    requestindate, clientmembercode, clientsubsystemcode,
     servicemembercode, servicesubsystemcode, servicecode
     ```
 
 5. Calculates the count of service calls between each unique combination of the fields:
 
     ```
-    clientmembercode, clientsubsystemcode, servicemembercode, 
+    clientmembercode, clientsubsystemcode, servicemembercode,
     servicesubsystemcode, servicecode
     ```
 
-6. Adds the following concatenate fields `client`, `producer`, `producer.service` 
+6. Adds the following concatenate fields `client`, `producer`, `producer.service`
    using newline escape sequence as a separator:
 
     ```
@@ -211,7 +237,7 @@ The data preparation step can be started by the command `xroad-metrics-networkin
     ```
 
 7. Parses member names from `riha.json` and adds the names to the output data.
-8. Writes the resulting table to RDS-file (R-specific binary file) 
+8. Writes the resulting table to RDS-file (R-specific binary file)
    in the shiny application's dynamic data directory (`/var/lib/xroad-metrics/networking`)
 
 The `xroad-metrics-networking` data preparation command is set up to run periodically using cron.
@@ -221,96 +247,96 @@ The `xroad-metrics-networking` data preparation command is set up to run periodi
 After the xroad-metrics-networking package and Shiny Server are installed and the data-preparation has been executed for the
 first time, the Visualization Web App UI can be accessed using a browser.
 
-By default the Shiny Server is configured to run on port 3838, so if the host where xroad-metrics-networking and Shiny Server 
+By default the Shiny Server is configured to run on port 3838, so if the host where xroad-metrics-networking and Shiny Server
 are installed is named e.g. *myshiny* you can access the UI by pointing your browser to http://myshiny:3838.
 
-The visualization web application enables the end-user to get visually illustrated information on the networking 
+The visualization web application enables the end-user to get visually illustrated information on the networking
 activity between the X-Road members. User can:
 
 1. Select to visualize all members or select one member.
 2. Select a "Top n" threshold to show only service calls reaching the highest n count of queries.
 3. Select the level of details with three options: member level, subsystem level, service level.
 4. Select whether the X-Road members are displayed as their registry codes or names.
-5. Select whether to include metaservices 
+5. Select whether to include metaservices
    (services related to the X-Road monitoring and service discovery).
 
 The visualization output includes two different graphs:
 
-1. The upper network graph shows members as circular nodes and arrows between the nodes to signify 
-   the connections between the members. Stronger color and thicker line indicates higher number of queries. 
+1. The upper network graph shows members as circular nodes and arrows between the nodes to signify
+   the connections between the members. Stronger color and thicker line indicates higher number of queries.
    The arrow points in a direction of client --> producer.
-2. The lower heatmap-type graph shows the same information but in a different form. 
-   The members in a producer role are plotted on the horizontal axis while the members in a client role are plotted 
-   on the vertical axis. The intersections (colored cells) of members on the horizontal and vertical axes indicate 
-   the number of queries between the given X-Road members. Greener colors signify lower number of queries and red 
+2. The lower heatmap-type graph shows the same information but in a different form.
+   The members in a producer role are plotted on the horizontal axis while the members in a client role are plotted
+   on the vertical axis. The intersections (colored cells) of members on the horizontal and vertical axes indicate
+   the number of queries between the given X-Road members. Greener colors signify lower number of queries and red
    colors higher number of colors.
 
-The numbers of queries between the members are logarithmed (log10) in both graphs in order to enable color and 
+The numbers of queries between the members are logarithmed (log10) in both graphs in order to enable color and
 line thickness graduations.
 
-The back-end of the web application a Shiny-framework web-app installed into `/usrr/share/xroad-metrics/networking/shiny/app.R`. 
-In addition to setting up the user interface, the script also does service call counting and logarithming. 
-The data file prepared by `prepare_data.R` includes counts of service calls on the service level. 
-For displaying X-Road member networking on the higher levels (member, subsystem), the `app.R` script reactively 
+The back-end of the web application a Shiny-framework web-app installed into `/usrr/share/xroad-metrics/networking/shiny/app.R`.
+In addition to setting up the user interface, the script also does service call counting and logarithming.
+The data file prepared by `prepare_data.R` includes counts of service calls on the service level.
+For displaying X-Road member networking on the higher levels (member, subsystem), the `app.R` script reactively
 sums the query counts.
 
 
-## Logging 
+## Logging
 
 ### Data preparation script
 
-The log files are stored by default at `/var/log/xroad-metrics/networking/logs`. 
-The local timestamp (YYYY-MM-DD hh:mm:ss), Unix timestamp, duration (hh:mm:ss), log information level (INFO, ERROR), 
+The log files are stored by default at `/var/log/xroad-metrics/networking/logs`.
+The local timestamp (YYYY-MM-DD hh:mm:ss), Unix timestamp, duration (hh:mm:ss), log information level (INFO, ERROR),
 activity and message are recorded in JSON structure:
 
 ```
 {
-  "module":"networking_module", 
-  "local_timestamp":"2017-11-16 20:32:16", 
-  "timestamp":1510857136, "duration":"00:00:01", 
-  "level":"INFO", 
-  "activity":"data preparation ended", 
+  "module":"networking_module",
+  "local_timestamp":"2017-11-16 20:32:16",
+  "timestamp":1510857136, "duration":"00:00:01",
+  "level":"INFO",
+  "activity":"data preparation ended",
   "msg":"1 rows were written for visualizer."
 }
 ```
 
-Heartbeat info is stored by default at `/var/log/xroad-metrics/networking/heartbeat`. 
+Heartbeat info is stored by default at `/var/log/xroad-metrics/networking/heartbeat`.
 Heartbeat has two statuses: SUCCEEDED and FAILED
 
 ```
 {
-  "module":"networking_module", 
-  "local_timestamp":"2017-11-16 20:32:16", 
-  "timestamp":1510857136, 
+  "module":"networking_module",
+  "local_timestamp":"2017-11-16 20:32:16",
+  "timestamp":1510857136,
   "msg":"SUCCEEDED"
 }
 ```
 
 ### Shiny Server
 
-Rstudio Shiny Server Open Source has its own built-in logging. 
-All information related to Shiny Server itself, rather than a particular Shiny application, 
-is logged in the global system log stored in `/var/log/shiny-server.log`. 
-Any errors and warnings that Shiny Server needs to communicate will be written here. 
-The application-specific logs, in this case the applications residing in `/usr/share/xroad-metrics/networking/shiny` subfolders, 
+Rstudio Shiny Server Open Source has its own built-in logging.
+All information related to Shiny Server itself, rather than a particular Shiny application,
+is logged in the global system log stored in `/var/log/shiny-server.log`.
+Any errors and warnings that Shiny Server needs to communicate will be written here.
+The application-specific logs, in this case the applications residing in `/usr/share/xroad-metrics/networking/shiny` subfolders,
 are logged separately and stored in `/var/log/shiny-server`. The log files are created in the following format:
 `<application directory name>-YYYMMDD-HHmmss-<port number or socket ID>.log`, e.g. `sample-shiny-20171021-232458-41093.log`.
 
-A log file will be created for each R process when it is started. However, if a process closes successfully, 
-the error log associated with that process will be automatically deleted. 
+A log file will be created for each R process when it is started. However, if a process closes successfully,
+the error log associated with that process will be automatically deleted.
 The only error log files that will remain on disk are those associated with R processes that did not exit as expected.
-For more information on the Shiny Server server level logging, 
+For more information on the Shiny Server server level logging,
 please see the [Server Log section of Shiny Server manual](http://docs.rstudio.com/shiny-server/#server-log).
 
-For more information on the Shiny Server application level logging, please see the 
+For more information on the Shiny Server application level logging, please see the
 [Logging and Analytics section of Shiny Server manual](http://docs.rstudio.com/shiny-server/#logging-and-analytics).
 
 ## Link Shiny Server application with Google Analytics ID
 
-Google Analytics ID can be added to Shiny web applications in Shiny Server configuration file 
-`/etc/shiny-server/shiny-server.conf`. 
-The following row must be added to the relevant application folder location 
-`google_analytics_id "UA-12345-1"` (ID to be replaced by a correct one). 
+Google Analytics ID can be added to Shiny web applications in Shiny Server configuration file
+`/etc/shiny-server/shiny-server.conf`.
+The following row must be added to the relevant application folder location
+`google_analytics_id "UA-12345-1"` (ID to be replaced by a correct one).
 
 Restart Shiny Server service after changes:
 
@@ -318,17 +344,17 @@ Restart Shiny Server service after changes:
 sudo service shiny-server restart
 ```
 
-For more information on how to use Google Analytics, including the method of how to set different Google Analytics IDs 
-to different applications, please see the 
+For more information on how to use Google Analytics, including the method of how to set different Google Analytics IDs
+to different applications, please see the
 [3.5.3 Google Analytics section of Shiny Server manual](http://docs.rstudio.com/shiny-server/#google-analytics).
 
 
 ## Possible optimization ideas
 
-At of the current implementation, `prepare_data.R` queries data from Opendata PostgreSQL database time interval in 30 days (configurable `interval=30` in `${APPDIR}/${INSTANCE}/networking_module/prepare_data_settings.R` and prepares everything based of that. 
-This might be memory-consuming. 
+At of the current implementation, `prepare_data.R` queries data from Opendata PostgreSQL database time interval in 30 days (configurable `interval=30` in `${APPDIR}/${INSTANCE}/networking_module/prepare_data_settings.R` and prepares everything based of that.
+This might be memory-consuming.
 Basically, there are next options to optimize usage of RAM:
 
 1. reduce interval
 2. implement logic to fetch data only in one day interval and append it into `/srv/shiny-server/${INSTANCE}/dat.rds`
-3. use R garbage collection utility gc() within `prepare_data.R` 
+3. use R garbage collection utility gc() within `prepare_data.R`

--- a/docs/opendata_module.md
+++ b/docs/opendata_module.md
@@ -8,23 +8,23 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 
 ## About
 
-The **Opendata module** is part of [X-Road Metrics](../README.md), 
+The **Opendata module** is part of [X-Road Metrics](../README.md),
 which includes the following modules:
  - [Database module](../database_module.md)
  - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md) 
- - [Reports module](../reports_module.md) 
+ - [Corrector module](../corrector_module.md)
+ - [Reports module](../reports_module.md)
  - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md) 
+ - [Opendata module](../opendata_module.md)
  - [Networking/Visualizer module](../networking_module.md)
 
-The **Opendata module** is used to publish the X-Road operational monitoring data. 
-The module has a UI and a REST API that allow filtering the anonymized operational monitoring data and downloading it 
+The **Opendata module** is used to publish the X-Road operational monitoring data.
+The module has a UI and a REST API that allow filtering the anonymized operational monitoring data and downloading it
 as gzip archives. The anonymized operational monitoring data is stored in a PostgreSQL database.
 
 ## Architecture
 
-Opendata module serves data that has been prepared by the [Anonymizer module](anonymizer_module.md)  
+Opendata module serves data that has been prepared by the [Anonymizer module](anonymizer_module.md)
 Overview of the module architecture related to publishing operational monitoring data
 through is in the diagram below:
  ![system diagram](img/opendata/opendata_overview.png "System overview")
@@ -54,8 +54,8 @@ The Opendata module installation has three main parts:
 2) Install and configure the PostgreSQL database
 3) Configure the Opendata UI
 
-This sections describes the necessary steps to install the **opendata module** on 
-an Ubuntu 20.04 Linux host. For a complete overview of different modules and machines, 
+This sections describes the necessary steps to install the **opendata module** on
+an Ubuntu 20.04 Linux host. For a complete overview of different modules and machines,
 please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
 
 
@@ -96,8 +96,8 @@ You have to fill in some environment specific settings to the settings file to m
 Refer to section [Opendata Module Configuration](#opendata-module-configuration)
 
 ## Database Setup
-Before installing the database, please install the X-Road Metrics as descibed above. 
-After the PostgreSQL database is installed and configured you can proceed to finish configuration of the 
+Before installing the database, please install the X-Road Metrics as descibed above.
+After the PostgreSQL database is installed and configured you can proceed to finish configuration of the
 Opendata module.
 
 First make sure that the `en_US.UTF-8` locale is configured in the operating system:
@@ -145,14 +145,14 @@ networking_ex  | K!~96(;4KpB+ | "K!~96(;4KpB+"
 ```
 
 Store the output to a secure location, e.g. to your password manager. These usernames and passwords are needed later
-to configure the X-Road Metrics modules. The 'Escaped Password' column contains the password in YAML 
+to configure the X-Road Metrics modules. The 'Escaped Password' column contains the password in YAML
 escaped format that can be directly added to the config files.
 
-Database relations and relevant indices will be created dynamically during the first run of 
+Database relations and relevant indices will be created dynamically during the first run of
 [Anonymizer module](anonymizer.md), according to the supplied configuration.
 
 **Note:** PostgreSQL doesn't allow dashes and case sensitivity comes with a hassle.
-This means that for PostgreSQL instance it is suggested to use underscores and lower characters. 
+This means that for PostgreSQL instance it is suggested to use underscores and lower characters.
 The `xroad-metrics-init-postgresql` does the required substitutions in usernames automatically.
 
 
@@ -191,7 +191,7 @@ Then edit the `/etc/postgresql/12/main/postgresql.conf` and change the *listen_a
 listen_addresses = '*'
 ```
 
-This says that PostgreSQL should listen on its defined port on all its network interfaces, 
+This says that PostgreSQL should listen on its defined port on all its network interfaces,
 including localhost and public available interfaces.
 
 Restart PostgreSQL:
@@ -199,9 +199,33 @@ Restart PostgreSQL:
 sudo systemctl restart postgresql
 ```
 
+### Establish encrypted SSL/TLS client connection
+
+For a connection to be known SSL-secured, SSL usage must be configured on both the client and the server before the connection is made.
+If it is only configured on the server, the client may end up sending sensitive information before it knows that the server requires high security.
+
+To ensure secure connections `ssl-mode` and `ssl-root-cert` parameterers has to be provided in settings file.
+Possible values for `ssl-mode`: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`
+For detailed information see https://www.postgresql.org/docs/current/libpq-ssl.html
+
+To configure path to the SSL root certificate, set `ssl-root-cert`
+
+Example of `/etc/settings.yaml` entry:
+```
+postgres:
+  host: localhost
+  port: 5432
+  user: postgres
+  password: *******
+  database-name: postgres
+  table-name: logs
+  ssl-mode: verify-full
+  ssl-root-cert: /etc/ssl/certs/root.crt
+```
+
 ### Setting up rotational logging for PostgreSQL
 
-PostgreSQL stores its logs by default in the directory `/var/lib/postgresql/12/main/pg_log/` specified in `/etc/postgresql/12/main/postgresql.conf`. 
+PostgreSQL stores its logs by default in the directory `/var/lib/postgresql/12/main/pg_log/` specified in `/etc/postgresql/12/main/postgresql.conf`.
 
 Set up daily logging and keep 7 days logs, we can make the following alterations to it:
 
@@ -271,7 +295,7 @@ The Apache Virtual Host configuration defines the hostname for the Opendata serv
 The Opendata module installer fills in the current hostname to Apache config file automatically.
 
 If your hostname changes, or the installer used wrong hostname, you can change the value by editing the Apache config
-file `/etc/apache2/sites-available/xroad-metrics-opendata.conf`. For example if your hostname is `myhost.mydomain.org` 
+file `/etc/apache2/sites-available/xroad-metrics-opendata.conf`. For example if your hostname is `myhost.mydomain.org`
 change the contents of the file to:
 ```
 Use XRoadMetricsOpendataVHost myhost.mydomain.org
@@ -284,14 +308,14 @@ sudo apache2ctl restart
 
 And then you can test accessing the Opendata UI by pointing your browser to `https://myhost.mydomain.org/`
 
-The instructions above should be sufficient for simple use cases. 
-For more advanced Apache configurations, e.g. to add more allowed alias names for the host, 
+The instructions above should be sufficient for simple use cases.
+For more advanced Apache configurations, e.g. to add more allowed alias names for the host,
 you need to modify the apache configuration template in `/etc/apache2/conf-available/xroad-metrics-opendata.conf`.
 
 ### Settings profiles
-The opendata module can show data for multiple X-Road instances using settings profiles. 
-For example to have profiles DEV, TEST and PROD create three copies of the `setting.yaml` 
-file named `settings_DEV.yaml`, `settings_TEST.yaml` and `settings_PROD.yaml` and 
+The opendata module can show data for multiple X-Road instances using settings profiles.
+For example to have profiles DEV, TEST and PROD create three copies of the `setting.yaml`
+file named `settings_DEV.yaml`, `settings_TEST.yaml` and `settings_PROD.yaml` and
 change the xroad-instance setting in the files.
 
 Then you can access different X-Road instances data by selecting the settings profile in the url:
@@ -308,15 +332,15 @@ Setup and run [Anonymizer module](./anonymizer_module.md) to upload anonymized d
 
 ## Opendata Interface documentation
 
-Opendata provides a simple GUI to query daily anonymized logs and relevant metafeatures.  
+Opendata provides a simple GUI to query daily anonymized logs and relevant metafeatures.
 User Guide can be found from ==> [here](opendata/user_guide/ug_opendata_interface.md) <==.
 
-Opendata provides a simple API to query daily anonymized logs and relevant metafeatures.  
+Opendata provides a simple API to query daily anonymized logs and relevant metafeatures.
 Documentation can be found from ==> [here](opendata/user_guide/ug_opendata_api.md) <==.
 
 ## Monitoring and Status
 
-### Logging 
+### Logging
 
 The settings for the log file in the settings file are the following:
 
@@ -329,7 +353,7 @@ xroad:
 logger:
   name: opendata
   module: opendata
-  
+
   # Possible logging levels from least to most verbose are:
   # CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG
   level: INFO
@@ -340,11 +364,11 @@ logger:
 
 ```
 
-The log file is written to `log-path` and log file name contains the X-Road instance name. 
+The log file is written to `log-path` and log file name contains the X-Road instance name.
 The above example configuration would write logs to `/var/log/xroad-metrics/opendata/logs/log_opendata_EXAMPLE.json`.
 
 
-The **opendata module** log handler is compatible with the logrotate utility. 
+The **opendata module** log handler is compatible with the logrotate utility.
 To configure log rotation for the example setup above, create the file:
 
 ```
@@ -381,7 +405,7 @@ logger:
 
 ```
 
-The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name. 
+The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name.
 The above example configuration would write logs to
  `/var/log/xroad-metrics/opendata/heartbeat/heartbeat_opendata_EXAMPLE.json`.
 

--- a/networking_module/etc/settings.yaml
+++ b/networking_module/etc/settings.yaml
@@ -26,6 +26,8 @@ postgres:
   port: 5432
   username: <FILL>
   password: <FILL>
+  ssl_mode:
+  ssl_root_cert:
 
 logger:
   log-path: /var/log/xroad-metrics/networking/logs

--- a/networking_module/prepare_data.R
+++ b/networking_module/prepare_data.R
@@ -60,6 +60,13 @@ path.membernames <- paste0('/usr/share/xroad-metrics/networking/membernames', pr
 xroad.descriptor <- settings$networking$"xroad-descriptor-file"
 days <- (settings$networking$interval + settings$networking$buffer)
 
+if ("ssl_mode" %in% names(settings$postgres)) {
+    Sys.setenv(PGSSLMODE = settings$postgres$ssl_mode)
+}
+if ("ssl_root_cert" %in% names(settings$postgres)) {
+    Sys.setenv(PGSSLROOTCERT = settings$postgres$ssl_root_cert)
+}
+
 tryCatch(
   con <- dbConnect(
     dbDriver("PostgreSQL"),

--- a/opendata_module/etc/settings.yaml
+++ b/opendata_module/etc/settings.yaml
@@ -27,6 +27,8 @@ postgres:
   password: <FILL>
   database-name: <FILL>
   table-name: logs
+  ssl-mode:
+  ssl-root-cert:
 
 logger:
   name: opendata


### PR DESCRIPTION
Changes are done to `anonymizer`, `opendata` and  `networking` modules.

1. Add entry to settings file to enable `sslmode`
2. Add entry to settings file to set path for SSL root certificate
3. Configure `psycopg2` (PostgreSQL python client) to initiate secure SSL connection in `anonymizer` and `opendata` modules.
4.  Configure `RPostgreSQL` (R PostgreSQL client) to initiate SSL connection in `networking` module
5. Update documentation to reflect give changes.