### PR TITLE
Opmondev-147:  make TLS connection to MongoDB from db clients possible

### DIFF
--- a/anonymizer_module/etc/settings.yaml
+++ b/anonymizer_module/etc/settings.yaml
@@ -74,6 +74,8 @@ mongodb:
   host: localhost
   user: <FILL>
   password: <FILL>
+  tls:
+  tls-ca-file:
 
 postgres:
   host: localhost

--- a/anonymizer_module/etc/settings.yaml
+++ b/anonymizer_module/etc/settings.yaml
@@ -74,7 +74,9 @@ mongodb:
   host: localhost
   user: <FILL>
   password: <FILL>
+  # set to True to enable secure connection
   tls:
+  # path to CA pem file
   tls-ca-file:
 
 postgres:

--- a/anonymizer_module/opmon_anonymizer/iio/mongodbmanager.py
+++ b/anonymizer_module/opmon_anonymizer/iio/mongodbmanager.py
@@ -35,7 +35,11 @@ class MongoDbManager(object):
         xroad = settings['xroad']['instance']
         self._logger = logger
 
-        self.client = MongoClient(self.get_mongo_uri(settings))
+        connect_args = {
+            'tls': bool(settings['mongodb'].get('tls')),
+            'tlsCAFile': settings['mongodb'].get('tls-ca-file'),
+        }
+        self.client = MongoClient(self.get_mongo_uri(settings), **connect_args)
         self.query_db = self.client[f"query_db_{xroad}"]
         self.state_db = self.client[f"anonymizer_state_{xroad}"]
 

--- a/collector_module/etc/settings.yaml
+++ b/collector_module/etc/settings.yaml
@@ -66,7 +66,9 @@ mongodb:
   host: localhost
   user: <FILL>
   password: <FILL>
+  # set to True to enable secure connection
   tls:
+  # path to CA pem file
   tls-ca-file:
 
 logger:

--- a/collector_module/etc/settings.yaml
+++ b/collector_module/etc/settings.yaml
@@ -1,6 +1,6 @@
 # Default settings file for X-Road Metrics Collector-module.
 # Fill in your MongoDB and X-Road configuration.
-# 
+#
 # To run collector for many different X-Road instances, you can create settings
 # profiles. For example to have profiles DEV, TEST and PROD copy this file to
 # settings_DEV.yaml, settings_TEST.yaml and settings_PROD.yaml.
@@ -26,11 +26,11 @@ collector:
   #   1 year = 31536000
   records-from-offset: 31536000
   records-to-offset: 100
-  
+
   # Repeat query to fetch additional data only if server has returned at least as much records.
   # By default servers should return 10000 records, so this value should be smaller.
   repeat-min-records: 50
-  
+
   # How many times to repeat query if server has more records ("nextRecordsFrom" is returned by previous query).
   # Set to 0 to disable query repeating.
   # If this value is too low and script is executed rarely then some data may be lost.
@@ -49,13 +49,13 @@ xroad:
     protocol: http://
     host: <FILL>
     timeout: 10
-  
+
   # Security server used to contact
   security-server:
     protocol: http://
     host: <FILL>
     timeout: 60.0
-  
+
   # X-Road service configuration used to fetch operational monitoring requests.
   monitoring-client:
     memberclass: <FILL>
@@ -66,11 +66,13 @@ mongodb:
   host: localhost
   user: <FILL>
   password: <FILL>
+  tls:
+  tls-ca-file:
 
 logger:
   name: collector
   module: collector
-  
+
   # Possible logging levels from least to most verbose are:
   # CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG
   level: INFO

--- a/corrector_module/etc/settings.yaml
+++ b/corrector_module/etc/settings.yaml
@@ -1,6 +1,6 @@
 # Default settings file for X-Road Metrics Corrector-module.
 # Fill in your MongoDB and X-Road configuration.
-# 
+#
 # To run corrector for many different X-Road instances, you can create settings
 # profiles. For example to have profiles DEV, TEST and PROD copy this file to
 # settings_DEV.yaml, settings_TEST.yaml and settings_PROD.yaml.
@@ -107,11 +107,13 @@ mongodb:
   host: localhost
   user: <FILL>
   password: <FILL>
+  tls:
+  tls-ca-file:
 
 logger:
   name: corrector
   module: corrector
-  
+
   # Possible logging levels from least to most verbose are:
   # CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG
   level: INFO

--- a/corrector_module/etc/settings.yaml
+++ b/corrector_module/etc/settings.yaml
@@ -107,7 +107,9 @@ mongodb:
   host: localhost
   user: <FILL>
   password: <FILL>
+  # set to True to enable secure connection
   tls:
+  # path to CA pem file
   tls-ca-file:
 
 logger:

--- a/corrector_module/opmon_corrector/database_manager.py
+++ b/corrector_module/opmon_corrector/database_manager.py
@@ -62,8 +62,14 @@ class DatabaseManager:
         self.settings = settings
         xroad = settings['xroad']['instance']
         self.logger_m = LoggerManager(settings['logger'], xroad, __version__)
-
-        self.client = pymongo.MongoClient(self.get_mongo_uri(settings))
+        connect_args = {
+            'tls': bool(settings['mongodb'].get('tls')),
+            'tlsCAFile': settings['mongodb'].get('tls-ca-file'),
+        }
+        self.client = pymongo.MongoClient(
+            self.get_mongo_uri(settings),
+            **connect_args
+        )
         self.mdb_database = f"query_db_{xroad}"
 
     @staticmethod

--- a/docs/database_module.md
+++ b/docs/database_module.md
@@ -14,15 +14,15 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 The **Database module** is part of [X-Road Metrics](../README.md), which includes the following modules:
  - [Database module](../database_module.md)
  - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md) 
- - [Reports module](../reports_module.md) 
+ - [Corrector module](../corrector_module.md)
+ - [Reports module](../reports_module.md)
  - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md) 
+ - [Opendata module](../opendata_module.md)
  - [Networking/Visualizer module](../networking_module.md)
 
-The **Database module** provides storage and synchronization between the other modules. 
+The **Database module** provides storage and synchronization between the other modules.
 
-Overall system, its users and rights, processes and directories are designed in a way, that all modules can reside in one server (different users but in same group 'xroad-metrics') but also in separate servers. 
+Overall system, its users and rights, processes and directories are designed in a way, that all modules can reside in one server (different users but in same group 'xroad-metrics') but also in separate servers.
 
 Overall system is also designed in a way, that allows to monitor data from different X-Road instances (e.g. in Estonia there are three instances: `ee-dev`, `ee-test` and `EE`.)
 
@@ -32,7 +32,7 @@ Overall system is also designed in a way, that can be used by X-Road Centre for 
 
 The database is implemented with the MongoDB technology: a non-SQL database with replication and sharding capabilities.
 
-This document describes the installation steps for Ubuntu 20.04. 
+This document describes the installation steps for Ubuntu 20.04.
 You can also refer to official [MongoDB 4.4 installation instructions](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/).
 
 Add the MongoDB APT repository and signing key:
@@ -123,7 +123,7 @@ Each X-Road Metrics module uses a different user to access MongoDB. This way the
 to bare minimum. The MongoDB users for all modules can be created automatically by using an init command that is
 installed with the X-Road Metrics Collector Module.
 
-At this point, please refer to the [installation guide of X-Road Metrics Collector](./collector_module.md) 
+At this point, please refer to the [installation guide of X-Road Metrics Collector](./collector_module.md)
 and install the collector package.
 
 To run the X-Road Metrics MongoDB init command you need the following information:
@@ -153,7 +153,7 @@ reports_EX             | Fdqay:76I}x5 | "Fdqay:76I}x5"
 ```
 
 Store the output to a secure location, e.g. to your password manager. These usernames and passwords are needed later
-to configure the X-Road Metrics modules. The 'Escaped Password' column contains the password in YAML 
+to configure the X-Road Metrics modules. The 'Escaped Password' column contains the password in YAML
 escaped format that can be directly added to the config files.
 
 The command also creates default MongoDB indexes needed by the X-Road Metrics modules. For more information about
@@ -170,7 +170,7 @@ mongo
 
 #### **read-only user (optional)**
 
-Inside the MongoDB client shell, create the **user_read** user in the **admin** database. 
+Inside the MongoDB client shell, create the **user_read** user in the **admin** database.
 Replace **USER_PWD** with the desired password (keep it in your password safe).
 
 ```
@@ -180,7 +180,7 @@ db.createUser( { user: "user_read", pwd: "USER_PWD", roles: ["readAnyDatabase"] 
 
 ### Check user configuration and permissions
 
-To check if all users and configurations were properly created, list all users and verify their roles using 
+To check if all users and configurations were properly created, list all users and verify their roles using
 the following commands inside the MongoDB client shell:
 
 ```
@@ -192,16 +192,16 @@ db.getUsers()
 
 For X-Road instance `EX` auth_db should have following users and access rights:
 
-* **anonymizer_EX**: 
+* **anonymizer_EX**:
     * query_db_EX: read
     * anonymizer_state_EX: readWrite
 * **collector_EX**:
-    * query_db_EX: readWrite, 
+    * query_db_EX: readWrite,
     * collcetor_state_EX: readWrite
-* **corrector_EX**: 
+* **corrector_EX**:
     * query_db_EX: readWrite
-* **reports_EX**: 
-    * query_db_EX: read, 
+* **reports_EX**:
+    * query_db_EX: read,
     * reports_state_EX: 'readWrite'
 
 
@@ -226,7 +226,7 @@ sudo vi /etc/logrotate.d/mongodb
 with content:
 
 ```yaml
-/var/log/mongodb/mongod.log { 
+/var/log/mongodb/mongod.log {
   daily
   rotate 30
   compress
@@ -249,7 +249,24 @@ Following modules need to have access to MongoDB:
     - Corrector
     - Reports
     - Anonymizer
-    
+
+
+### Establish encrypted SSL/TLS client connection
+
+Every module has own settings to use secure connection to MongoDB.
+Database server has to be preconfigured to accept encrypted connection from client side.
+See https://www.mongodb.com/docs/manual/reference/program/mongod/#options for details.
+
+To enable TLS connection from client side, configure `mongodb` section in
+module's settings file. Example:
+```
+mongodb:
+  host: host
+  user: user
+  password: *****
+  tls: True
+  tls-ca-file: /path/to/ca/pem/file
+```
 
 ### Log Configuration
 
@@ -274,17 +291,17 @@ Log files:
 The `xroad-metrics-init-mongo` command documented in chapter [Automatic User and Index Creation](#Automatic User and Index Creation)
 creates a default set of indexes to MongoDB. If your application needs some further indexes, those can be added in the MongoDB shell.
 
-Although indexes can improve query performances, indexes also present some operational considerations. 
+Although indexes can improve query performances, indexes also present some operational considerations.
 See [MongoDB Operational Considerations for Indexes](https://docs.mongodb.com/manual/core/data-model-operations/#data-model-indexes) for more information.
-Our collection holds a large amount of data, and our applications need to be able to access the data while building the 
-index, therefore we consider building the index in the background, as described in 
+Our collection holds a large amount of data, and our applications need to be able to access the data while building the
+index, therefore we consider building the index in the background, as described in
 [Background Construction](https://docs.mongodb.com/manual/core/index-creation/#index-creation-background).
 
 
 **Note 1**: If planning to select / filter records manually according to different fields, then please consider to create index for every field to allow better results.
 From other side, if these are not needed, please consider to drop them as the existence reduces overall speed of [Corrector module](corrector_module.md).
 
-**Note 2**: Additional indexes might required for system scripts in case of functionality changes (eg different reports). 
+**Note 2**: Additional indexes might required for system scripts in case of functionality changes (eg different reports).
 Please consider to create them as they speed up significantly the speed of [Reports module](reports_module.md).
 
 **Note 3**: Index build might affect availability of cursor for long-running queries.
@@ -292,7 +309,7 @@ Please review the need of active [Collector module](collector_module.md) and spe
 
 ### Index Recreation
 
-It might happen, that under heavy and continuos write activities to database, the indexes corrupt. 
+It might happen, that under heavy and continuos write activities to database, the indexes corrupt.
 In result, read access from database takes long time, it can be monitored also from current log file `/var/log/mongodb/mongod.log`, where in COMMANDs the last parameter protocol:op_query  in milliseconds (ms) is large even despite usage of indexes (planSummary: IXSCAN { }).
 
 In such cases, dropping and creating indexes again or reIndex() process might be the solution.
@@ -327,7 +344,7 @@ already been processed by the corrector (`{"corrected": true}`).
 
 ## MongoDB Compass
 
-It is also possible to monitor MongoDB with a GUI interface using the MongoDB Compass. 
+It is also possible to monitor MongoDB with a GUI interface using the MongoDB Compass.
 For specific instructions, please refer to:
 
 ```
@@ -342,7 +359,7 @@ https://docs.mongodb.com/master/administration/monitoring/
 
 ## Database backup
 
-To perform backup of database, it is recommended to use the mongodb tools **mongodump** and **mongorestore** 
+To perform backup of database, it is recommended to use the mongodb tools **mongodump** and **mongorestore**
 
 For additional details and recommendations about MongoDB backup and restore tools, please check:
 
@@ -352,7 +369,7 @@ https://docs.mongodb.com/manual/tutorial/backup-and-restore-tools/
 
 ## Database replication
 
-MongoDB supports replication. A replica set in MongoDB is a group of mongod processes that maintain the same data set. 
+MongoDB supports replication. A replica set in MongoDB is a group of mongod processes that maintain the same data set.
 Replica sets provide redundancy and high availability, and are the basis for all production deployments.
 
 Sample to add replication, add the following line in the configuration file:
@@ -374,7 +391,7 @@ After saving the alterations, the MongoDB service needs to be restarted. This ca
 sudo service mongod restart
 ```
 
-To make mongod instance as master, the following commands are needed in mongod shell 
+To make mongod instance as master, the following commands are needed in mongod shell
 (in this example, if the machine running MongoDB has the Ethernet IP `10.11.22.33`):
 
 ```
@@ -388,7 +405,7 @@ To make mongod instance as master, the following commands are needed in mongod s
 
 To build or rebuild indexes for a replica set, see [Build Indexes on Replica Sets](https://docs.mongodb.com/manual/tutorial/build-indexes-on-replica-sets/#index-building-replica-sets).
 
-For additional details and recommendations about MongoDB replication set, please check 
+For additional details and recommendations about MongoDB replication set, please check
 [MongoDB Manual Replication](https://docs.mongodb.com/manual/replication/)
 
 To change the size of oplog, follow the steps

--- a/reports_module/etc/settings.yaml
+++ b/reports_module/etc/settings.yaml
@@ -10,6 +10,10 @@ mongodb:
   host: localhost
   user: <FILL>
   password: <FILL>
+  # set to True to enable secure connection
+  tls:
+  # path to CA pem file
+  tls-ca-file:
 
 logger:
   name: reports

--- a/reports_module/opmon_reports/mongodb_handler.py
+++ b/reports_module/opmon_reports/mongodb_handler.py
@@ -36,13 +36,17 @@ class MongoDBHandler:
         pwd = urllib.parse.quote(mongo_settings['password'], safe='')
         server = mongo_settings['host']
         self.uri = f"mongodb://{self.user}:{pwd}@{server}/auth_db"
+        self.connect_args = {
+            'tls': bool(mongo_settings.get('tls')),
+            'tlsCAFile': mongo_settings.get('tls-ca-file'),
+        }
 
     def get_query_db(self):
-        client = pymongo.MongoClient(self.uri)
+        client = pymongo.MongoClient(self.uri, **self.connect_args)
         db = client[self.db_name]
         return db
 
     def get_reports_state_db(self):
-        client = pymongo.MongoClient(self.uri)
+        client = pymongo.MongoClient(self.uri, **self.connect_args)
         db = client[self.db_reports_state_name]
         return db


### PR DESCRIPTION
This change effects `anonymizer`, `collector`, `corrector` and `reports`  modules.

1. Add entry `tls` to settings file to enable `TLS`.
2. Add entry to settings file to set path for SSL certificate `tls-ca-file`.
3. Configure `pymongo` (MongoDB python client) to initiate secure SSL connection.

Update documentation to reflect give changes.