### PR TITLE
[OPMONDEV-158]: fix documentation links and update corrector documentation

### DIFF
--- a/docs/anonymizer_module.md
+++ b/docs/anonymizer_module.md
@@ -129,7 +129,7 @@ To use anonymizer you need to fill in your X-Road, MongoDB and PostgreSQL config
 (here, **vi** is used):
 
 ```bash
-sudo vi /etc/xroad-metrics/corrector/settings.yaml
+sudo vi /etc/xroad-metrics/anonymizer/settings.yaml
 ```
 
 Settings that the user must fill in:

--- a/docs/anonymizer_module.md
+++ b/docs/anonymizer_module.md
@@ -225,7 +225,7 @@ file named `settings_DEV.yaml`, `settings_TEST.yaml` and `settings_PROD.yaml`.
 Then fill the profile specific settings to each file and use the --profile
 flag when running xroad-metrics-anonymizer. For example to run anonymizer manually using the TEST profile:
 ```
-xroad-metrics-correctord --profile TEST
+xroad-metrics-anonymizer --profile TEST
 ```
 
 `xroad-metrics-anonymizer` command searches the settings file first in current working direcrtory, then in
@@ -298,7 +298,7 @@ logger:
 ```
 
 The log file is written to `log-path` and log file name contains the X-Road instance name.
-The above example configuration would write logs to `/var/log/xroad-metrics/collector/logs/log_collector_EXAMPLE.json`.
+The above example configuration would write logs to `/var/log/xroad-metrics/anonymizer/logs/log_anonymizer_EXAMPLE.json`.
 
 
 The **anonymizer module** log handler is compatible with the logrotate utility.
@@ -310,7 +310,7 @@ sudo vi /etc/logrotate.d/xroad-metrics-anonymizer
 
 and add the following content :
 ```
-/var/log/xroad-metrics/collector/logs/log_anonymizer_EXAMPLE.json {
+/var/log/xroad-metrics/anonymizer/logs/log_anonymizer_EXAMPLE.json {
     rotate 10
     size 2M
 }

--- a/docs/anonymizer_module.md
+++ b/docs/anonymizer_module.md
@@ -13,13 +13,13 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 
 The **Anonymizer module** is part of [X-Road Metrics](../README.md),
 which include following modules:
- - [Database module](../database_module.md)
- - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md)
- - [Reports module](../reports_module.md)
- - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md)
- - [Networking/Visualizer module](../networking_module.md)
+ - [Database module](./database_module.md)
+ - [Collector module](./collector_module.md)
+ - [Corrector module](./corrector_module.md)
+ - [Reports module](./reports_module.md)
+ - [Anonymizer module](./anonymizer_module.md)
+ - [Opendata module](./opendata_module.md)
+ - [Networking/Visualizer module](./networking_module.md)
 
 The **Anonymizer module** is responsible of preparing the operational monitoring data for publication through
 the [Opendata module](opendata_module.md). Anonymizer configuration allows X-Road Metrics extension administrator to set

--- a/docs/collector_module.md
+++ b/docs/collector_module.md
@@ -12,13 +12,13 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 ## About
 
 The **Collector module** is part of [X-Road Metrics](../README.md), which includes the following modules:
- - [Database module](../database_module.md)
- - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md)
- - [Reports module](../reports_module.md)
- - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md)
- - [Networking/Visualizer module](../networking_module.md)
+ - [Database module](./database_module.md)
+ - [Collector module](./collector_module.md)
+ - [Corrector module](./corrector_module.md)
+ - [Reports module](./reports_module.md)
+ - [Anonymizer module](./anonymizer_module.md)
+ - [Opendata module](./opendata_module.md)
+ - [Networking/Visualizer module](./networking_module.md)
 
 The **Collector module** is responsible to retrieve data from X-Road Security Servers and insert into the database module. The execution of the collector module is performed automatically via a **cron job** task.
 
@@ -167,14 +167,14 @@ SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # m   h  dom mon dow  user       command
-  15 */6  *   *   *   xroad-metrics  /usr/share/xroad-metrics/collector/scripts/cron/cron_collector.sh PROD
-  30 */6  *   *   *   xroad-metrics  /usr/share/xroad-metrics/collector/scripts/cron/cron_collector.sh TEST
+  15 */6  *   *   *   xroad-metrics  xroad-metrics-collector --profile PROD update && xroad-metrics-collector --profile PROD collect
+  30 */6  *   *   *   xroad-metrics  xroad-metrics-collector --profile TEST update && xroad-metrics-collector --profile TEST collect
 
 ```
 
 If collector is to be run only manually, comment out the default cron task:
 ```bash
-# 15 */6 * * * xroad-metrics /usr/share/xroad-metrics/collector/scripts/cron/cron_collector.sh
+# 20 */3  *   *   *   xroad-metrics      xroad-metrics-collector update && xroad-metrics-collector collect
 ```
 
 ### Note about Indexing

--- a/docs/corrector_module.md
+++ b/docs/corrector_module.md
@@ -12,19 +12,19 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 ## About
 
 The **Corrector module** is part of [X-Road Metrics](../README.md), which includes the following modules:
- - [Database module](../database_module.md)
- - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md) 
- - [Reports module](../reports_module.md) 
- - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md) 
- - [Networking/Visualizer module](../networking_module.md)
+ - [Database module](./database_module.md)
+ - [Collector module](./collector_module.md)
+ - [Corrector module](./corrector_module.md)
+ - [Reports module](./reports_module.md)
+ - [Anonymizer module](./anonymizer_module.md)
+ - [Opendata module](./opendata_module.md)
+ - [Networking/Visualizer module](./networking_module.md)
 
 The **Corrector module** is responsible to clean the raw data from corrector and derive monitoring metrics in a clean database collection. The execution of the corrector module is performed automatically via a **service** task.
 
 It is important to note that it can take up to 7 days for the [Collector module](collector_module.md) to receive X-Road operational data from (all available) Security Server(s) and up to 3 days for the Corrector_module to clean the raw data and derive monitoring metrics in a clean database collection.
 
-Overall system, its users and rights, processes and directories are designed in a way, that all modules can reside in one server (different users but in same group 'xroad-metrics') but also in separate servers. 
+Overall system, its users and rights, processes and directories are designed in a way, that all modules can reside in one server (different users but in same group 'xroad-metrics') but also in separate servers.
 
 Overall system is also designed in a way, that allows to monitor data from different X-Road instances (e.g. in Estonia there are three instances: `ee-dev`, `ee-test` and `EE`.)
 
@@ -38,8 +38,8 @@ The module source code can be found at:
 ![corrector module diagram](img/Corrector_module_diagram_v2.svg "Corrector module diagram")
 
 ## Pair matching logic
-The first step is to add the missing fields into the document (in case it is missing some). 
-The value will be "None" for the missing fields. 
+The first step is to add the missing fields into the document (in case it is missing some).
+The value will be "None" for the missing fields.
 The fields that MUST be there for each document are the following:
 
 ```
@@ -56,14 +56,14 @@ The fields that MUST be there for each document are the following:
 Before finding a match, a hash is calculated for the current document. The following fields are included:
 
 ```
-'monitoringDataTs', 'securityServerInternalIp', 'securityServerType', 'requestInTs', 
-‘requestOutTs', 'responseInTs', 'responseOutTs', 'clientXRoadInstance', 'clientMemberClass', 
-'clientMemberCode', 'clientSubsystemCode', 'serviceXRoadInstance', 'serviceMemberClass', 
-'serviceMemberCode', 'serviceSubsystemCode', 'serviceCode', 'serviceVersion', 
-'representedPartyClass', 'representedPartyCode', 'messageId', 'messageUserId', 
-'messageIssue', 'messageProtocolVersion', 'clientSecurityServerAddress', 
-'serviceSecurityServerAddress', 'requestSoapSize', 'requestMimeSize', 
-‘requestAttachmentCount', 'responseSoapSize', 'responseMimeSize', ‘responseAttachmentCount', 
+'monitoringDataTs', 'securityServerInternalIp', 'securityServerType', 'requestInTs',
+‘requestOutTs', 'responseInTs', 'responseOutTs', 'clientXRoadInstance', 'clientMemberClass',
+'clientMemberCode', 'clientSubsystemCode', 'serviceXRoadInstance', 'serviceMemberClass',
+'serviceMemberCode', 'serviceSubsystemCode', 'serviceCode', 'serviceVersion',
+'representedPartyClass', 'representedPartyCode', 'messageId', 'messageUserId',
+'messageIssue', 'messageProtocolVersion', 'clientSecurityServerAddress',
+'serviceSecurityServerAddress', 'requestSoapSize', 'requestMimeSize',
+‘requestAttachmentCount', 'responseSoapSize', 'responseMimeSize', ‘responseAttachmentCount',
 'succeeded', 'soapFaultCode', 'soapFaultString'
 ```
 
@@ -73,7 +73,7 @@ The fields excluded from the hash are the following:
 '_id', 'insertTime' 'corrected'
 ```
 
-After calculating the hash it is checked that the hash doesn't already exist in the DB (clean_data). 
+After calculating the hash it is checked that the hash doesn't already exist in the DB (clean_data).
 If it does exist, the document is skipped.
 
 If the hash doesn't exist, then possible matches are queried for the document.
@@ -209,7 +209,7 @@ systemctl status xroad-metrics-corrector
 ```
 
 ### Settings Profiles
-To run corrector for multiple X-Road instances, a settings profile for each instance can be created. For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml` 
+To run corrector for multiple X-Road instances, a settings profile for each instance can be created. For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml`
 file named `settings_DEV.yaml`, `settings_TEST.yaml` and `settings_PROD.yaml`.
 Then fill the profile specific settings to each file and use the --profile
 flag when running xroad-metrics-correctord. For example to run corrector manually using the TEST profile:
@@ -255,7 +255,7 @@ Please review the need of active Corrector module while running long-running que
 
 ## Monitoring and Status
 
-### Logging 
+### Logging
 
 The settings for the log file in the settings file are the following:
 
@@ -268,7 +268,7 @@ xroad:
 logger:
   name: corrector
   module: corrector
-  
+
   # Possible logging levels from least to most verbose are:
   # CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG
   level: INFO
@@ -279,7 +279,7 @@ logger:
 
 ```
 
-The log file is written to `log-path` and log file name contains the X-Road instance name. 
+The log file is written to `log-path` and log file name contains the X-Road instance name.
 The above example configuration would write logs to `/var/log/xroad-metrics/collector/logs/log_corrector_EXAMPLE.json`.
 
 Every log line includes:
@@ -334,7 +334,7 @@ logger:
 
 ```
 
-The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name. 
+The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name.
 The above example configuration would write logs to `/var/log/xroad-metrics/corrector/heartbeat/heartbeat_corrector_EXAMPLE.json`.
 
 The heartbeat file consists last message of log file and status

--- a/docs/database_module.md
+++ b/docs/database_module.md
@@ -12,13 +12,13 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 ## About
 
 The **Database module** is part of [X-Road Metrics](../README.md), which includes the following modules:
- - [Database module](../database_module.md)
- - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md)
- - [Reports module](../reports_module.md)
- - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md)
- - [Networking/Visualizer module](../networking_module.md)
+ - [Database module](./database_module.md)
+ - [Collector module](./collector_module.md)
+ - [Corrector module](./corrector_module.md)
+ - [Reports module](./reports_module.md)
+ - [Anonymizer module](./anonymizer_module.md)
+ - [Opendata module](./opendata_module.md)
+ - [Networking/Visualizer module](./networking_module.md)
 
 The **Database module** provides storage and synchronization between the other modules.
 

--- a/docs/networking_module.md
+++ b/docs/networking_module.md
@@ -12,13 +12,13 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 ## About
 
 The Networking module is part of [X-Road Metrics](../README.md). All other modules in X-Road Operational Monitoring are:
- - [Database module](../database_module.md)
- - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md)
- - [Reports module](../reports_module.md)
- - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md)
- - [Networking/Visualizer module](../networking_module.md)
+ - [Database module](./database_module.md)
+ - [Collector module](./collector_module.md)
+ - [Corrector module](./corrector_module.md)
+ - [Reports module](./reports_module.md)
+ - [Anonymizer module](./anonymizer_module.md)
+ - [Opendata module](./opendata_module.md)
+ - [Networking/Visualizer module](./networking_module.md)
 
 The purpose of the **Networking module** is to visualize the networking activity between the X-Road members.
 It consists of:

--- a/docs/opendata_module.md
+++ b/docs/opendata_module.md
@@ -10,13 +10,13 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 
 The **Opendata module** is part of [X-Road Metrics](../README.md),
 which includes the following modules:
- - [Database module](../database_module.md)
- - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md)
- - [Reports module](../reports_module.md)
- - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md)
- - [Networking/Visualizer module](../networking_module.md)
+ - [Database module](./database_module.md)
+ - [Collector module](./collector_module.md)
+ - [Corrector module](./corrector_module.md)
+ - [Reports module](./reports_module.md)
+ - [Anonymizer module](./anonymizer_module.md)
+ - [Opendata module](./opendata_module.md)
+ - [Networking/Visualizer module](./networking_module.md)
 
 The **Opendata module** is used to publish the X-Road operational monitoring data.
 The module has a UI and a REST API that allow filtering the anonymized operational monitoring data and downloading it

--- a/docs/reports_module.md
+++ b/docs/reports_module.md
@@ -12,24 +12,24 @@ To view a copy of this license, visit <https://creativecommons.org/licenses/by-s
 ## About
 
 The **Reports module** is part of [X-Road Metrics](../README.md), which includes the following modules:
- - [Database module](../database_module.md)
- - [Collector module](../collector_module.md)
- - [Corrector module](../corrector_module.md) 
- - [Reports module](../reports_module.md) 
- - [Anonymizer module](../anonymizer_module.md)
- - [Opendata module](../opendata_module.md) 
- - [Networking/Visualizer module](../networking_module.md)
+ - [Database module](./database_module.md)
+ - [Collector module](./collector_module.md)
+ - [Corrector module](./corrector_module.md)
+ - [Reports module](./reports_module.md)
+ - [Anonymizer module](./anonymizer_module.md)
+ - [Opendata module](./opendata_module.md)
+ - [Networking/Visualizer module](./networking_module.md)
 
 The **Reports module** is responsible for creating monthly reports about subsystems of X-Road members (datasets usage).
 The execution of the reports module can be either performed automatically (via **cron job**) or manually.
 
 Overall system, its users and rights, processes and directories are designed in a way, that all modules can reside in
-one server (different users but in same group 'xroad-metrics') but also in separate servers.  
+one server (different users but in same group 'xroad-metrics') but also in separate servers.
 
-Overall system is also designed in a way, that allows to monitor data from different X-Road instances 
+Overall system is also designed in a way, that allows to monitor data from different X-Road instances
 (e.g. in Estonia there are three instances: `ee-dev`, `ee-test` and `EE`.)
 
-Overall system is also designed in a way, that can be used by X-Road Centre for all X-Road members as well as for 
+Overall system is also designed in a way, that can be used by X-Road Centre for all X-Road members as well as for
 Member own monitoring (includes possibilities to monitor also members data exchange partners).
 
 
@@ -103,8 +103,8 @@ Settings that the user must fill in:
 * username and password for the reports-module MongoDB user
 * e-mail template, SMTP server and port
 
-To run xroad-metrics-reports for multiple X-Road instances, a settings profile for each instance can be created. 
-For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml` file named 
+To run xroad-metrics-reports for multiple X-Road instances, a settings profile for each instance can be created.
+For example to have profiles DEV, TEST and PROD create three copies of `setting.yaml` file named
 `settings_DEV.yaml`, `settings_TEST.yaml` and `settings_PROD.yaml`.
 Then fill the profile specific settings to each file and use the --profile
 flag when running xroad-metrics-reports. For example to run using the TEST profile:
@@ -129,11 +129,11 @@ Report language translation files can be found in path _/etc/xroad-metrics/repor
 By default the Reports Module will generate a report for each subsystem that has acted as a client or producer
 of at least one request during the report period. This subsystem list is fetched automatically from the Database Module.
 Since this method relies solely on the operational monitoring data it has following limitations:
-    
+
 1. e-mail notifications cannot be sent for the generated reports
 2. localized subsystem names are not available in the reports, only codes
 
-The report target subsystems can be defined in full detail manually by using a xroad-descriptor json file as 
+The report target subsystems can be defined in full detail manually by using a xroad-descriptor json file as
 described in chapter [X-Road Descriptor File](#x-road-descriptor-file)
 
 If you want to generate a report for a single subsystem it is also possible to use a command line argument like this:
@@ -143,11 +143,11 @@ xroad-metrics-reports report --subsystem MYCLASS:MYMEMBER:MYSUB
 
 ### X-Road Descriptor File
 
-The settings.yaml file has a setting named *xroad.descriptor-path* that is blank by default. 
-This can be set pointing to a file that contains a list of all X-Road subsystems that should be subject to report 
-generation. The file can also contain additional information about the subsystems; currently maintainer e-mail 
+The settings.yaml file has a setting named *xroad.descriptor-path* that is blank by default.
+This can be set pointing to a file that contains a list of all X-Road subsystems that should be subject to report
+generation. The file can also contain additional information about the subsystems; currently maintainer e-mail
 addresses and localized subsystem names are supported.
- 
+
 Below is an example of a xroad-descriptor file format:
 
 ```json
@@ -179,8 +179,8 @@ Below is an example of a xroad-descriptor file format:
 ]
 ```
 
-The file format is based on RIHA (Estonian catalogue of public sector information systems, https://www.riha.ee) 
-interfaces. Currently there is no standardized way to generate this file automatically as it contains information 
+The file format is based on RIHA (Estonian catalogue of public sector information systems, https://www.riha.ee)
+interfaces. Currently there is no standardized way to generate this file automatically as it contains information
 that is not available in the standard X-Road Central Server interfaces.
 
 
@@ -206,11 +206,11 @@ xroad-metrics-reports --profile TEST notify
 ```
 
 ### Cron settings
-Default installation includes a cronjob in _/etc/cron.d/xroad-metrics-reports-cron_ that runs reports-module monthly. 
+Default installation includes a cronjob in _/etc/cron.d/xroad-metrics-reports-cron_ that runs reports-module monthly.
 This job runs reports module using the default settings profile (_/etc/xroad-metrics/reports/settings.yaml_)
 
-It is important to note that it can take several days for ==> [Collector module](collector_module.md) <== to receive 
-the operational data from Security Server(s) and for the ==> [Corrector_module](corrector_module.md) <== to 
+It is important to note that it can take several days for ==> [Collector module](collector_module.md) <== to receive
+the operational data from Security Server(s) and for the ==> [Corrector_module](corrector_module.md) <== to
 clean the raw data and derive monitoring metrics in a clean database collection if the X-Road instance has a lot of members.
 
 This means that if monthly reports are to be generated, the cron job should run **after** the collector and corrector
@@ -236,14 +236,14 @@ If reports-generation is to be run only manually, comment out the default cron t
 
 ### Publishing Reoprts
 Using default settings the xroad-metrics-reports command generates report pdf files into folder _/home/xroad-metrics/reports_.
-If you want to publish the reports on some external file server, you can setup e.g. a rsync cronjob. 
+If you want to publish the reports on some external file server, you can setup e.g. a rsync cronjob.
 Below example assumes your file-server hostname is _myfileserver_ and user _myuser_ can access it with from the
 xroad-metrics-reports host.
 
 TODO: add example when file server strategy has been confirmed. OPMONDEV-63
 
 If you don't use any external file server users can copy the reports to their workstations using e.g. _scp_ command.
-TODO: add example  
+TODO: add example
 
 ### E-mail Notifications
 TODO: Add documentation after the default notification strategy has been confirmed. OPMONDEV-63
@@ -251,14 +251,14 @@ TODO: Add documentation after the default notification strategy has been confirm
 
 ### Note about Indexing
 
-Index build in background (see [Database module, Index Creation](database_module.md#index-creation) might affect 
+Index build in background (see [Database module, Index Creation](database_module.md#index-creation) might affect
 availability of cursor for long-running queries.
-Please review the need of active [Collector module](collector_module.md) and specifically the need of active 
+Please review the need of active [Collector module](collector_module.md) and specifically the need of active
 [Corrector module](corrector_module.md) while running Reports.
 
 ## Monitoring and Status
 
-### Logging 
+### Logging
 
 The settings for the log file in the settings file are the following:
 
@@ -271,7 +271,7 @@ xroad:
 logger:
   name: reports
   module: reports
-  
+
   # Possible logging levels from least to most verbose are:
   # CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG
   level: INFO
@@ -282,7 +282,7 @@ logger:
 
 ```
 
-The log file is written to `log-path` and log file name contains the X-Road instance name. 
+The log file is written to `log-path` and log file name contains the X-Road instance name.
 The above example configuration would write logs to `/var/log/xroad-metrics/reports/logs/log_reports_EXAMPLE.json`.
 
 Every log line includes:
@@ -331,7 +331,7 @@ logger:
 
 ```
 
-The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name. 
+The heartbeat file is written to `heartbeat-path` and hearbeat file name contains the X-Road instance name.
 The above example configuration would write logs to `/var/log/xroad-metrics/reports/heartbeat/heartbeat_reports_EXAMPLE.json`.
 
 The heartbeat file consists last message of log file and status


### PR DESCRIPTION
1. Update outdated documentation for `corrector_module`
2. Fix broken Markdown links