### PR TITLE
[OPMONDEV-156]: update documentation to install Metrics on Ubuntu 22.04

### DIFF
--- a/docs/anonymizer_module.md
+++ b/docs/anonymizer_module.md
@@ -77,7 +77,7 @@ postgres:
 ## Installation
 
 This sections describes the necessary steps to install the **anonymizer module** on
-an Ubuntu 20.04 Linux host. For a complete overview of different modules and machines,
+an Ubuntu 20.04 or Ubuntu 22.04 Linux host. For a complete overview of different modules and machines,
 please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
 
 

--- a/docs/collector_module.md
+++ b/docs/collector_module.md
@@ -43,7 +43,7 @@ No incoming connection is needed in the collector module.
 
 ## Installation
 
-This sections describes the necessary steps to install the **collector module** on a Ubuntu 20.04 Linux host. For a complete overview of different modules and machines, please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
+This sections describes the necessary steps to install the **collector module** on a Ubuntu 20.04 or Ubuntu 22.04 Linux host. For a complete overview of different modules and machines, please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
 
 
 ### Add X-Road Extensions Package Repository for Ubuntu

--- a/docs/corrector_module.md
+++ b/docs/corrector_module.md
@@ -123,7 +123,7 @@ No **incoming** connection is needed in the corrector module.
 
 ## Installation
 
-This sections describes the necessary steps to install the **corrector module** on a Ubuntu 20.04 Linux host. For a complete overview of different modules and machines, please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
+This sections describes the necessary steps to install the **corrector module** on a Ubuntu 20.04 or Ubuntu 22.04 Linux host. For a complete overview of different modules and machines, please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
 
 
 ### Add X-Road Extensions Package Repository for Ubuntu

--- a/docs/database_module.md
+++ b/docs/database_module.md
@@ -32,16 +32,26 @@ Overall system is also designed in a way, that can be used by X-Road Centre for 
 
 The database is implemented with the MongoDB technology: a non-SQL database with replication and sharding capabilities.
 
-This document describes the installation steps for Ubuntu 20.04.
-You can also refer to official [MongoDB 4.4 installation instructions](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/).
+This document describes the installation steps for Ubuntu 20.04 or Ubuntu 22.04.
+You can also refer to official [MongoDB 4.4 installation instructions](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/) for Ubuntu 20.04.
+Refer to official [MongoDB 6.0 installation instructions](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/) for Ubuntu 22.04.
 
-Add the MongoDB APT repository and signing key:
+## Add the MongoDB APT repository and signing key for Ubuntu 20.04
 
 ```bash
 # Key rsa4096/20691eec35216c63caf66ce1656408e390cfb1f5 [expires: 2024-05-26]
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 656408e390cfb1f5
 sudo apt-add-repository "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse"
 ```
+
+## Add the MongoDB APT repository and signing key for Ubuntu 22.04
+
+```bash
+# Key rsa4096/39bd841e4be5fb195a65400e6a26b1ae64c3c388 [expires: 2027-02-22T]
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 6a26b1ae64c3c388
+sudo apt-add-repository "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse"
+```
+
 
 Install MongoDB server and client tools (shell)
 
@@ -77,8 +87,16 @@ sudo systemctl restart mongod.service
 We want only authenticated users to have access to MongoDB.
 To enable authentication, enter MongoDB shell:
 
+#### For MongoDB 4.4 on Ubuntu 20.04
+
 ```bash
 mongo
+```
+
+#### For MongoDB 6.0 on Ubuntu 22.04
+
+```bash
+mongosh
 ```
 
 Issue the following commands to create a *root* user:

--- a/docs/networking_module.md
+++ b/docs/networking_module.md
@@ -37,7 +37,7 @@ The general scheme of processes in the Networkin module is as follows:
 
 ![networking module diagram](img/Networking_module_diagram.png "Networking module diagram")
 
-### Add X-Road Extensions Package Repository for Ubuntu
+### Add X-Road Extensions Package Repository for Ubuntu 20.04 or Ubuntu 22.04
 ````bash
 wget -qO - https://artifactory.niis.org/api/gpg/key/public | sudo apt-key add -
 sudo add-apt-repository 'https://artifactory.niis.org/xroad-extensions-release-deb main'

--- a/docs/opendata_module.md
+++ b/docs/opendata_module.md
@@ -55,7 +55,7 @@ The Opendata module installation has three main parts:
 3) Configure the Opendata UI
 
 This sections describes the necessary steps to install the **opendata module** on
-an Ubuntu 20.04 Linux host. For a complete overview of different modules and machines,
+an Ubuntu 20.04 or Ubuntu 22.04 Linux host. For a complete overview of different modules and machines,
 please refer to the ==> [System Architecture](system_architecture.md) <== documentation.
 
 
@@ -162,7 +162,15 @@ We need to enable remote access to PostgreSQL since Anonymizer and Networking mo
 
 In this example we assume that Anonymizer host IP is 172.31.0.1 and Networking host IP is 172.31.0.2.
 
-Add the following lines to `/etc/postgresql/12/main/pg_hba.conf` in order to
+#### For PostgreSQL 12 on Ubuntu 20.04
+
+Edit `/etc/postgresql/12/main/pg_hba.conf`
+
+#### For PostgreSQL 14 on Ubuntu 22.04
+
+Edit `/etc/postgresql/14/main/pg_hba.conf`
+
+Add the following lines to the config in order to
 enable password authentication (md5 hash comparison) from Anonymizer and Networking hosts:
 
 ```
@@ -186,7 +194,7 @@ host    all    all   0.0.0.0/0    reject
 
 **Note:** `host` type access can be substituted with `hostssl` if using SSL-encrypted connections.
 
-Then edit the `/etc/postgresql/12/main/postgresql.conf` and change the *listen_addresses* to
+Then edit the `/etc/postgresql/12/main/postgresql.conf` or `/etc/postgresql/14/main/pg_hba.conf` and change the *listen_addresses* to
 ```
 listen_addresses = '*'
 ```
@@ -225,7 +233,7 @@ postgres:
 
 ### Setting up rotational logging for PostgreSQL
 
-PostgreSQL stores its logs by default in the directory `/var/lib/postgresql/12/main/pg_log/` specified in `/etc/postgresql/12/main/postgresql.conf`.
+PostgreSQL stores its logs by default in the directory `/var/lib/postgresql/{pg_version}/main/pg_log/` specified in `/etc/postgresql/{pg_version}/main/postgresql.conf`.
 
 Set up daily logging and keep 7 days logs, we can make the following alterations to it:
 


### PR DESCRIPTION
Update documentation to support installation of Metrics on Ubuntu 22.04