### PR TITLE
[OPMONDEV-158]: fix Django settings error

### DIFF
--- a/opendata_module/opmon_opendata/django_settings.py
+++ b/opendata_module/opmon_opendata/django_settings.py
@@ -63,7 +63,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'opmon_opendata',
-    'opmon_opendata.api.apps.ApiConfig'
+    'opmon_opendata.api.apps.ApiConfig',
     'opmon_opendata.gui.apps.GuiConfig',
 ]
 


### PR DESCRIPTION
Missing comma added to Django settings