### PR TITLE
[Opmondev -162]: opendata_module: fix Django 2.2.28 and Django 3.2.18 compatibility issue

### DIFF
--- a/opendata_module/opmon_opendata/tests/test_api.py
+++ b/opendata_module/opmon_opendata/tests/test_api.py
@@ -236,7 +236,6 @@ def test_get_harvest_default_ordering(db, http_client):
 
     query = {
         'from_dt': '2022-11-07T07:00:00',
-        # 'order': json.dumps({'av': 'sdfsfs'})
     }
     response = http_client.get('/api/harvest', query)
     assert response.status_code == 200
@@ -328,6 +327,19 @@ def test_get_harvest_error_from_dt_later_until_dt(http_client):
     assert response_data['errors'] == {
         'from_dt': ['Ensure the value is not later than until_dt'],
         'until_dt': ['Ensure the value is not earlier than from_dt']
+    }
+
+
+def test_get_harvest_error_invalid_json(http_client):
+    query = {
+        'from_dt': '2022-12-13T07:00:00',
+        'order': 'not valid'
+    }
+    response = http_client.get('/api/harvest', query)
+    assert response.status_code == 400
+    response_data = response.json()
+    assert response_data['errors'] == {
+        'order': ['Ensure "order" is valid json']
     }
 
 

--- a/opendata_module/setup.py
+++ b/opendata_module/setup.py
@@ -27,7 +27,7 @@ from setuptools import setup, find_packages
 requirements = [
     'setuptools==67.4.0',
     'dill==0.3.1.1',
-    'django==2.2.28',
+    'django==3.2.18',
     'pymongo==3.10.1',
     'pyyaml==5.4.1',
     'psycopg2==2.8.6',

--- a/opendata_module/test_requirements.txt
+++ b/opendata_module/test_requirements.txt
@@ -4,7 +4,6 @@ pytest-mock
 pytest-pycodestyle
 mongomock
 psycopg2-binary
-django==3.2.18
 pytest-django
 python-dateutil
 freezegun

--- a/opendata_module/tox.ini
+++ b/opendata_module/tox.ini
@@ -1,14 +1,23 @@
 [tox]
-envlist = py38-{pytest,mypy}
+envlist = py38-{pytest,mypy,legacy_django}
 
 [testenv]
-deps = -rtest_requirements.txt
+deps =
+    django==3.2.18
+    -r test_requirements.txt
 [testenv:py38-pytest]
 install_command=pip install --only-binary=numpy {opts} numpy {packages}
 commands =
     - coverage run --source opmon_opendata -m pytest opmon_opendata/
     coverage report --include=opmon_opendata/*
     coverage html -d ../htmlcov/opendata_module --include=opmon_opendata/*
+[testenv:py38-legacy_django]
+deps =
+    django==2.2.28
+    -r test_requirements.txt
+install_command=pip install --only-binary=numpy {opts} numpy {packages}
+commands =
+    - coverage run --source opmon_opendata -m pytest opmon_opendata/
 [testenv:py38-mypy]
 description = Run mypy
 deps =


### PR DESCRIPTION
1. `JSONField` was introduced in Django 3.1
https://docs.djangoproject.com/en/3.2/ref/models/fields/#django.db.models.JSONField
2. Date and time iso format was not included in `forms.DateTimeField`  `input_formats ` in Django 2.2.28
3. Add  test env in tox.ini to cover test cases for legacy Django 2.2.28