### PR TITLE
[OPMONDEV-162]: Fix /api/harvest endpoint to return relevant data

### DIFF
--- a/opendata_module/opmon_opendata/api/forms.py
+++ b/opendata_module/opmon_opendata/api/forms.py
@@ -1,8 +1,8 @@
 import datetime
 import json
 
-import pytz
 from django import forms
+import pytz
 
 # Django 2.2 does not support this format by default
 INPUT_FORMATS = [
@@ -11,14 +11,8 @@ INPUT_FORMATS = [
 
 
 class HarvestForm(forms.Form):
-    from_dt = forms.DateTimeField(
-        required=True,
-        input_formats=INPUT_FORMATS,
-    )
-    until_dt = forms.DateTimeField(
-        required=False,
-        input_formats=INPUT_FORMATS,
-    )
+    from_dt = forms.DateTimeField(required=True, input_formats=INPUT_FORMATS)
+    until_dt = forms.DateTimeField(required=False, input_formats=INPUT_FORMATS)
     offset = forms.IntegerField(required=False)
     limit = forms.IntegerField(required=False, min_value=0)
     from_row_id = forms.IntegerField(required=False)

--- a/opendata_module/opmon_opendata/api/forms.py
+++ b/opendata_module/opmon_opendata/api/forms.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+import pytz
 from django import forms
 
 # Django 2.2 does not support this format by default
@@ -10,17 +11,36 @@ INPUT_FORMATS = [
 
 
 class HarvestForm(forms.Form):
-    from_dt = forms.DateTimeField(required=True, input_formats=INPUT_FORMATS)
-    until_dt = forms.DateTimeField(required=False, input_formats=INPUT_FORMATS)
+    from_dt = forms.DateTimeField(
+        required=True,
+        input_formats=INPUT_FORMATS,
+    )
+    until_dt = forms.DateTimeField(
+        required=False,
+        input_formats=INPUT_FORMATS,
+    )
     offset = forms.IntegerField(required=False)
     limit = forms.IntegerField(required=False, min_value=0)
+    from_row_id = forms.IntegerField(required=False)
     # compatibility with Django 2.2
     order = forms.CharField(required=False)
+    timestamp_tz = forms.CharField(required=False)
 
     def clean(self):
         cleaned_data = super().clean()
+        tz = pytz.utc
+        if cleaned_data.get('timestamp_tz'):
+            tz = pytz.timezone(cleaned_data['timestamp_tz'])
         from_dt = cleaned_data.get('from_dt')
+        if from_dt:
+            cleaned_data['from_dt'] = from_dt.replace(
+                tzinfo=tz
+            )
         until_dt = cleaned_data.get('until_dt')
+        if until_dt:
+            cleaned_data['until_dt'] = until_dt.replace(
+                tzinfo=tz
+            )
         if from_dt and until_dt:
             if from_dt > until_dt:
                 self.add_error('from_dt', 'Ensure the value is not later than until_dt')
@@ -52,3 +72,14 @@ class HarvestForm(forms.Form):
             if order['order'].upper() not in ALLOWED_ORDER_ORDER_VALUES:
                 raise forms.ValidationError('Ensure only "ASC" or "DESC" is set for order')
         return order
+
+    def clean_timestamp_tz(self):
+        timestamp_tz_value = self.cleaned_data.get('timestamp_tz')
+        if timestamp_tz_value:
+            try:
+                pytz.timezone(timestamp_tz_value)
+            except pytz.exceptions.UnknownTimeZoneError:
+                raise forms.ValidationError(
+                    'Ensure the value is valid timezone'
+                )
+        return timestamp_tz_value

--- a/opendata_module/opmon_opendata/api/postgresql_manager.py
+++ b/opendata_module/opmon_opendata/api/postgresql_manager.py
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import psycopg2 as pg
 from dateutil import relativedelta
@@ -49,7 +49,7 @@ class PostgreSQL_Manager(object):
 
         return [(self._field_name_map[name], type_) for name, type_ in data]
 
-    def get_rows_count(self, constraints) -> Tuple[int]:
+    def get_rows_count(self, constraints: List[Dict[str, object]]) -> Tuple[int]:
         """
         Returns the number of rows in the specified table that satisfy the given constraints.
 

--- a/opendata_module/opmon_opendata/tests/test_api.py
+++ b/opendata_module/opmon_opendata/tests/test_api.py
@@ -193,7 +193,6 @@ def test_get_harvest_from(db, http_client, caplog):
 
 
 def test_get_harvest_from_row_id(db, http_client):
-
     log_factory(db, request_in_dt='2022-11-07T07:50:00', id=1)
     log_factory(db, request_in_dt='2022-11-07T08:00:00', id=2)
 
@@ -231,7 +230,8 @@ def test_get_harvest_timestamp_tz(db, http_client):
     assert response.status_code == 200
     response_data = response.json()
     data = response_data.get('data')
-    assert len(data) == 3
+    actual_request_in_dates = [row[10] for row in data]
+    assert actual_request_in_dates == ['1667805600000', '1667809200000', '1667812800000']
 
 
 def test_get_harvest_timestamp_tz_not_valid(db, http_client):

--- a/opendata_module/setup.py
+++ b/opendata_module/setup.py
@@ -31,7 +31,8 @@ requirements = [
     'pymongo==3.10.1',
     'pyyaml==5.4.1',
     'psycopg2==2.8.6',
-    'python-dateutil==2.8.1'
+    'python-dateutil==2.8.1',
+    'pytz==2023.3'
 ]
 
 classifiers = [

--- a/opendata_module/test_requirements.txt
+++ b/opendata_module/test_requirements.txt
@@ -8,3 +8,4 @@ pytest-django
 python-dateutil
 freezegun
 django-stubs
+pytz


### PR DESCRIPTION
1. Return `total_query_count`. It allows to define if pagination is needed
2. Use `from_row_id` for querying. It allows to filter logs more precisely.
3. Use timezone to prepare timestamps for querying. Each timestamp in logs are generated taking timezone into account