### PR TITLE
[Opmondev-162]: use CharField instead of DateTimeField to fix replaced plus sign

### DIFF
--- a/opendata_module/opmon_opendata/api/forms.py
+++ b/opendata_module/opmon_opendata/api/forms.py
@@ -3,39 +3,69 @@ import json
 
 from django import forms
 
-# Django 2.2 does not support this format by default
-INPUT_FORMATS = [
-    '%Y-%m-%dT%H:%M:%S%z',
-]
+DT_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
 
 
 class HarvestForm(forms.Form):
-    from_dt = forms.DateTimeField(required=True, input_formats=INPUT_FORMATS)
-    until_dt = forms.DateTimeField(required=False, input_formats=INPUT_FORMATS)
+    from_dt = forms.CharField(required=True)
+    until_dt = forms.CharField(required=False)
     offset = forms.IntegerField(required=False)
     limit = forms.IntegerField(required=False, min_value=0)
     from_row_id = forms.IntegerField(required=False)
     # compatibility with Django 2.2
     order = forms.CharField(required=False)
 
+    @staticmethod
+    def get_timestamp_with_tz_offset(timestamp):
+        timestamp = timestamp.replace(' ', '+')
+        return timestamp
+
     def clean(self):
+        from_dt = None
+        until_dt = None
         cleaned_data = super().clean()
-        from_dt = cleaned_data.get('from_dt')
-        until_dt = cleaned_data.get('until_dt')
-        if from_dt and until_dt:
+        from_dt_str = cleaned_data.get('from_dt')
+        if from_dt_str:
+            from_dt = datetime.datetime.strptime(from_dt_str, DT_FORMAT)
+        until_dt_str = cleaned_data.get('until_dt')
+        if from_dt_str and until_dt_str:
+            until_dt = datetime.datetime.strptime(until_dt_str, DT_FORMAT)
             if from_dt > until_dt:
-                self.add_error('from_dt', 'Ensure the value is not later than until_dt')
-                self.add_error('until_dt', 'Ensure the value is not earlier than from_dt')
+                self.add_error(
+                    'from_dt', 'Ensure the value is not later than until_dt'
+                )
+                self.add_error(
+                    'until_dt', 'Ensure the value is not earlier than from_dt'
+                )
+        cleaned_data['from_dt'] = from_dt
+        cleaned_data['until_dt'] = until_dt
         return cleaned_data
 
     def clean_from_dt(self):
         now = datetime.datetime.now(datetime.timezone.utc)
         from_dt_value = self.cleaned_data['from_dt']
-        if now < from_dt_value:
+        from_dt_value = HarvestForm.get_timestamp_with_tz_offset(from_dt_value)
+        try:
+            from_dt = datetime.datetime.strptime(from_dt_value, DT_FORMAT)
+        except ValueError:
+            self.add_error('from_dt', f'Ensure the value matches format {DT_FORMAT}')
+            return
+        if now < from_dt:
             raise forms.ValidationError(
                 'Ensure the value is not later than the current date and time'
             )
         return from_dt_value
+
+    def clean_until_dt(self):
+        until_dt_value = self.cleaned_data['until_dt']
+        if until_dt_value:
+            until_dt_value = HarvestForm.get_timestamp_with_tz_offset(until_dt_value)
+            try:
+                datetime.datetime.strptime(until_dt_value, DT_FORMAT)
+            except ValueError:
+                self.add_error('until_dt', f'Ensure the value matches format {DT_FORMAT}')
+                return
+        return until_dt_value
 
     def clean_order(self):
         ALLOWED_ORDER_KEYS = ['column', 'order']

--- a/opendata_module/opmon_opendata/api/forms.py
+++ b/opendata_module/opmon_opendata/api/forms.py
@@ -16,7 +16,7 @@ class HarvestForm(forms.Form):
     order = forms.CharField(required=False)
 
     @staticmethod
-    def get_timestamp_with_tz_offset(timestamp):
+    def get_timestamp_with_tz_offset(timestamp: str) -> str:
         timestamp = timestamp.replace(' ', '+')
         return timestamp
 


### PR DESCRIPTION
The problem: `+` sign is replaced with space in HTTP, because it is a reserved symbol.

When we pass 'from_dt': '2022-11-07T07:00:00+0000' to url, Django will raise a `ValueError` because datetime object can't be build using string '2022-11-07T07:00:00 0000'.

There were an option to encode passed query params and than to decode it in Django views and pass it to the form. In this way `+` should be preserved. Maybe.

I choose more easiest way, because don't want to spend more time on this problem today and fix it in correct way later.
1. Use `CharField` instead of `DateTimeField`
2. Replace empty string in with `+` sign if such case exists
3. Check if given datetime string is valid and can be used to construct a datetime object