### PR TITLE
[Opmondev-163]:  minor fixes

### DIFF
--- a/opendata_collector_module/metrics_opendata_collector/opendata_api_client.py
+++ b/opendata_collector_module/metrics_opendata_collector/opendata_api_client.py
@@ -94,7 +94,7 @@ class OpenDataAPIClient:
                 )
         return params
 
-    def get_opendata(self, params_overrides: Optional[dict] = None) -> dict:
+    def do_request(self, params_overrides: Optional[dict] = None) -> dict:
         """
         Gets the OpenData API response.
             Args:

--- a/opendata_collector_module/metrics_opendata_collector/tests/test_opendata_collector.py
+++ b/opendata_collector_module/metrics_opendata_collector/tests/test_opendata_collector.py
@@ -140,6 +140,7 @@ def test_collect_opendata_gets_until(set_dir, mocker, mock_mongo_db, caplog):
     ]
     assert 'TEST-SOURCE1: fetching opendata from_dt: 2023-03-28T00:00:00+0000, from_row_id: None' in caplog.text
     assert 'TEST-SOURCE1: total inserted 90 opendata documents into MongoDB' in caplog.text
+    assert 'until_dt: 2023-03-28T23:59:59+0000' in caplog.text
 
 
 def test_collect_opendata_with_state(set_dir, mocker, mock_mongo_db, caplog):


### PR DESCRIPTION
1. Reduce log entries by removing "inserted n opendata documents into MongoDB". We still have log entry about totals
2. Rename functions: `_do_request()` ->  `get_opendata()` and `get_opendata()` ->  `do_request()`