### PR TITLE
Opmondev-162]:  fix Opendata row range when returned rows are less than limit

### DIFF
--- a/opendata_module/opmon_opendata/tests/test_api.py
+++ b/opendata_module/opmon_opendata/tests/test_api.py
@@ -332,6 +332,29 @@ def test_get_harvest_from_with_limit(db, http_client):
     assert response_data['row_range'] == '1-4'
 
 
+def test_get_harvest_rows_less_than_limit(db, http_client):
+
+    log_factory(db, request_in_dt='2022-11-07T10:34:00')
+    log_factory(db, request_in_dt='2022-11-08T08:00:00')
+
+    query = {
+        'from_dt': '2022-11-05T08:00:00+0000',
+        'limit': 100
+    }
+    response = http_client.get('/api/harvest', query)
+    assert response.status_code == 200
+    response_data = response.json()
+    data = response_data.get('data')
+    assert len(data) == 2
+    actual_request_in_dates = [row[11] for row in data]
+    assert actual_request_in_dates == [
+        '2022-11-07',
+        '2022-11-08',
+    ]
+    assert response_data['limit'] == 100
+    assert response_data['row_range'] == '1-2'
+
+
 def test_get_harvest_total_query_count(db, http_client):
     log_factory(db, request_in_dt='2022-11-10T08:00:00')
     log_factory(db, request_in_dt='2022-11-08T08:20:00')

--- a/opendata_module/opmon_opendata/tests/test_api.py
+++ b/opendata_module/opmon_opendata/tests/test_api.py
@@ -333,7 +333,6 @@ def test_get_harvest_from_with_limit(db, http_client):
 
 
 def test_get_harvest_rows_less_than_limit(db, http_client):
-
     log_factory(db, request_in_dt='2022-11-07T10:34:00')
     log_factory(db, request_in_dt='2022-11-08T08:00:00')
 


### PR DESCRIPTION
Log entry: "received 102 rows from total 2902 within range 2801-3000", "version": "0.1.0"}"

Incorrect:   within range 2801-3000
Correct:  within range 2801-2903