### PR TITLE
Metrics POC: do not create opendata_collector MongoDB user automatically

### DIFF
--- a/collector_module/opmon_mongodb_maintenance/create_indexes.py
+++ b/collector_module/opmon_mongodb_maintenance/create_indexes.py
@@ -39,7 +39,6 @@ indexRequests = [
         'indexes': [
             [('xRequestId', ASC)],
             [('correctorTime', ASC)],
-            [('insertTime', ASC)],
             [('correctorStatus', ASC), ('client.requestInTs', ASC)],
             [('correctorStatus', ASC), ('producer.requestInTs', ASC)],
             [('correctorStatus', ASC), ('xRequestId', ASC)],

--- a/collector_module/opmon_mongodb_maintenance/create_users.py
+++ b/collector_module/opmon_mongodb_maintenance/create_users.py
@@ -72,11 +72,13 @@ def _create_admin_users(args, client, passwords):
 
 
 def _create_opmon_users(args, client, passwords):
-    filtered_user_roles = {
-        key: value for key, value in user_roles.items()
-        if (args.user_to_generate and key == args.user_to_generate)
-        or (not args.user_to_generate and key not in explicit_roles)
-    }
+    filtered_user_roles = {}
+    for key, value in user_roles.items():
+        if not args.user_to_generate and key not in explicit_roles:
+            filtered_user_roles[key] = value
+        if args.user_to_generate and key == args.user_to_generate:
+            filtered_user_roles[args.user_to_generate] = value
+
     for user, roles in filtered_user_roles.items():
         user_name = f'{user}_{args.xroad}'
         role_list = [{'db': f'{db}_{args.xroad}', 'role': role} for db, role in roles.items()]

--- a/collector_module/opmon_mongodb_maintenance/create_users.py
+++ b/collector_module/opmon_mongodb_maintenance/create_users.py
@@ -31,6 +31,8 @@ import secrets
 
 import yaml
 
+
+explicit_roles = ['opendata_collector']
 user_roles = {
     'analyzer': {'query_db': 'read', 'analyzer_database': 'readWrite'},
     'analyzer_interface': {'query_db': 'read', 'analyzer_database': 'readWrite'},
@@ -70,7 +72,12 @@ def _create_admin_users(args, client, passwords):
 
 
 def _create_opmon_users(args, client, passwords):
-    for user, roles in user_roles.items():
+    filtered_user_roles = {
+        key: value for key, value in user_roles.items()
+        if (args.user_to_generate and key == args.user_to_generate)
+        or (not args.user_to_generate and key not in explicit_roles)
+    }
+    for user, roles in filtered_user_roles.items():
         user_name = f'{user}_{args.xroad}'
         role_list = [{'db': f'{db}_{args.xroad}', 'role': role} for db, role in roles.items()]
         password = user_name if args.dummy_passwords else _generate_password()

--- a/collector_module/opmon_mongodb_maintenance/main.py
+++ b/collector_module/opmon_mongodb_maintenance/main.py
@@ -67,6 +67,7 @@ def _parse_args():
     parser.add_argument("--dummy-passwords", action="store_true",
                         help="Skip generation of secure passwords for users. Password will be same as username.")
     parser.add_argument("--generate-admins", action="store_true", help="Also generate admin users.")
+    parser.add_argument("--user-to-generate", help="Generate specific user.", default=None)
     args = parser.parse_args()
 
     return args

--- a/collector_module/opmon_mongodb_maintenance/tests/test_create_users.py
+++ b/collector_module/opmon_mongodb_maintenance/tests/test_create_users.py
@@ -74,16 +74,16 @@ def test_admin_user_generation_without_passwords(mocker):
 
 
 def test_opmon_user_generation(mocker):
-    args = Namespace(xroad='XRD1', dummy_passwords=False)
+    args = Namespace(xroad='XRD1', dummy_passwords=False, user_to_generate=None)
     client = mocker.Mock()
 
     passwords = {}
     create_users._create_opmon_users(args, client, passwords)
 
     client.auth_db.command.assert_called()
-    assert client.auth_db.command.call_count == 7
-    assert len(passwords) == 7
-    assert len(set(passwords.values())) == 7  # passwords are unique
+    assert client.auth_db.command.call_count == 6
+    assert len(passwords) == 6
+    assert len(set(passwords.values())) == 6  # passwords are unique
 
     for pwd in passwords.values():
         assert len(pwd) >= 12
@@ -93,21 +93,40 @@ def test_opmon_user_generation(mocker):
         assert to_find in passwords.keys()
 
 
+def test_specific_metrics_user_generation(mocker):
+    args = Namespace(xroad='XRD1', dummy_passwords=False, user_to_generate='opendata_collector')
+    client = mocker.Mock()
+
+    passwords = {}
+    create_users._create_opmon_users(args, client, passwords)
+    client.auth_db.command.assert_called()
+    assert client.auth_db.command.call_count == 1
+    assert len(passwords) == 1
+    assert len(set(passwords.values())) == 1  # passwords are unique
+
+    for pwd in passwords.values():
+        assert len(pwd) >= 12
+
+    for user in opmon_user_names:
+        to_find = f'opendata_collector_{args.xroad}'
+        assert to_find in passwords.keys()
+
+
 def test_opmon_user_generation_without_passwords(mocker):
-    args = Namespace(xroad='XRD2', dummy_passwords=True)
+    args = Namespace(xroad='XRD2', dummy_passwords=True, user_to_generate=None)
     client = mocker.Mock()
 
     passwords = {}
     create_users._create_opmon_users(args, client, passwords)
 
     client.auth_db.command.assert_called()
-    assert client.auth_db.command.call_count == 7
-    assert len(set(passwords.values())) == 7  # passwords are unique
+    assert client.auth_db.command.call_count == 6
+    assert len(set(passwords.values())) == 6  # passwords are unique
 
     for user, pwd in passwords.items():
         assert user == pwd
 
-    assert len(passwords.keys()) == 7
+    assert len(passwords.keys()) == 6
     for user in opmon_user_names:
         to_find = f'{user}_{args.xroad}'
         assert to_find in passwords.keys()

--- a/docs/database_module.md
+++ b/docs/database_module.md
@@ -169,7 +169,6 @@ anonymizer_EX          | U'7<^)0&-b8s | "U'7<^)0&-b8s"
 collector_EX           | 7,zj3q1!CN#m | "7,zj3q1!CN#m"
 corrector_EX           | kf^{E4G/4[f0 | "kf^{E4G/4[f0"
 reports_EX             | Fdqay:76I}x5 | "Fdqay:76I}x5"
-opendata_collector_EX  | S382)@ldfiId | "S382)@ldfiId"
 ```
 
 Store the output to a secure location, e.g. to your password manager. These usernames and passwords are needed later
@@ -179,6 +178,21 @@ escaped format that can be directly added to the config files.
 The command also creates default MongoDB indexes needed by the X-Road Metrics modules. For more information about
 the indexes, see chapter [Indexes](#Indexes).
 
+### Single User creation.
+Each user for the X-Road Metrics module can be installed individually. To do this, use the
+`--user-to-generate` parameter as shown below:
+```bash
+sudo su xroad-metrics
+xroad-metrics-init-mongo --host xroad-metrics-centraldb:27017 --user root --password mysecret EX --user-to-generate opendata_collector
+```
+The command above creates user with the password.
+
+```bash
+Username                      | Password     | Escaped Password
+------------------------------+--------------+--------------------
+opendata_collector_PLAYGROUND | 108@#fZ~d[SP | "108@#fZ~d[SP"
+Created 20 indexes.
+```
 
 ### Manually Create Optional Users
 This Chapter can be skipped unless you want to install the optional users for integration test or read-only use.

--- a/docs/opendata_collector_module.md
+++ b/docs/opendata_collector_module.md
@@ -77,7 +77,7 @@ Refer to section [Opendata Collector Configuration](#opendata-collector-configur
 ### Opendata Collector Configuration
 
 Before using the opendata collector module, make sure you have installed and configured the [Database_Module](database_module.md)
-and created the MongoDB credentials.
+and created the MongoDB credentials. For this module, specific MongoDB user `opendata_collector` has to be created. See [Database_Module](database_module.md#single-user-creation)
 
 To use opendata collector you need to fill in your X-Road and MongoDB configuration into the settings file.
 (here, **vi** is used):


### PR DESCRIPTION
We don't want providers to create opendata_collector MongoDB user created by running DB initialisation  script.
Only Metrics Platform admin creates it using new parameter `--user-to-generate`:
```
xroad-metrics-init-mongo --host xroad-metrics-centraldb:27017 --user root --password mysecret EX --user-to-generate opendata_collector
```