### PR TITLE
[OpMONDEV-179]: add member and service data to metrics statistics

### DIFF
--- a/anonymizer_module/etc/settings.yaml
+++ b/anonymizer_module/etc/settings.yaml
@@ -81,6 +81,10 @@ anonymizer:
   # By default no rules are defined and all fields are included in the anonymized records.
   substitution-rules: []
 
+metrics-statistics:
+  # how many services sorted by requests counts to store in PG
+  num-max-services-requests:
+
 mongodb:
   host: localhost
   user: <FILL>

--- a/anonymizer_module/etc/settings.yaml
+++ b/anonymizer_module/etc/settings.yaml
@@ -10,6 +10,17 @@
 
 xroad:
   instance: <FILL>
+  # Security server used to collect member statistics
+  security-server:
+    protocol: http://
+    host: <FILL>
+    timeout: 60.0
+    # path to client's certificate
+    tls-client-certificate:
+    # path to client's private key
+    tls-client-key:
+    # path to server's certificate
+    tls-server-certificate:
 
 anonymizer:
   # Field data file is a schema file for the data format used by Opendata module.

--- a/anonymizer_module/metrics_statistics/central_server_client.py
+++ b/anonymizer_module/metrics_statistics/central_server_client.py
@@ -1,0 +1,122 @@
+#  The MIT License
+#  Copyright (c) 2021- Nordic Institute for Interoperability Solutions (NIIS)
+#  Copyright (c) 2017-2020 Estonian Information System Authority (RIA)
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import re
+import xml.etree.ElementTree as ET
+from logging import Logger
+from typing import Dict, Sequence, TypedDict
+
+import requests
+
+
+class MemberCountData(TypedDict):
+    member_gov_count: int
+    member_com_count: int
+    member_org_count: int
+
+
+class MemberData(TypedDict):
+    member_class: str
+    member_code: str
+
+
+class CentralServerClient:
+    def __init__(self, xroad_settings: dict, logger: Logger):
+        self.url = f"{xroad_settings['central-server']['protocol']}{xroad_settings['central-server']['host']}"
+        self.timeout = xroad_settings['central-server']['timeout']
+        self.logger = logger
+
+    def get_members(self) -> Sequence[MemberData]:
+        try:
+            shared_params = self._get_shared_params()
+            return self._parse_members_list(shared_params)
+        except Exception as e:
+            self.logger.exception(f'CentralServerClient.get_members: {repr(e)}')
+            raise e
+
+    def get_member_count(self) -> MemberCountData:
+        members_list = self.get_members()
+        unique_counts: Dict[str, set] = {}
+
+        for member in members_list:
+            member_class = member['member_class']
+            member_code = member['member_code']
+            member_count_key = f'member_{member_class.lower()}_count'
+
+            if member_count_key not in unique_counts:
+                unique_counts[member_count_key] = set()
+
+            if member_code:
+                unique_counts[member_count_key].add(member_code)
+        members_count: MemberCountData = {
+            'member_gov_count': len(unique_counts['member_gov_count']),
+            'member_com_count': len(unique_counts['member_com_count']),
+            'member_org_count': len(unique_counts['member_org_count'])
+        }
+        return members_count
+
+    def _get_shared_params(self) -> requests.Response:
+        internal_conf_url = f'{self.url}/internalconf'
+
+        global_conf = requests.get(internal_conf_url, timeout=self.timeout)
+        global_conf.raise_for_status()
+        #  NB! re.search global configuration regex might be changed
+        # according version naming or other future naming conventions
+        data = global_conf.content.decode('utf-8')
+        s = re.search(r'Content-location: (/V\d+/\d+/shared-params.xml)', data)
+        if s is None:
+            raise ValueError('Pattern was not found in data')
+        shared_params = requests.get(f'{self.url}{s.group(1)}', timeout=self.timeout)
+        shared_params.raise_for_status()
+        return shared_params
+
+    @staticmethod
+    def _parse_members_list(shared_params: requests.Response) -> Sequence[MemberData]:
+        members_list = []
+
+        root = ET.fromstring(shared_params.content)
+        for server in root.findall('./securityServer'):
+            if server is None:
+                continue
+            owner_id = server.find('./owner')
+            if owner_id is None:
+                continue
+            owner = root.find("./member[@id='{0}']".format(owner_id.text))
+            if owner is None:
+                continue
+
+            member_class = owner.find('./memberClass/code')
+            member_code = owner.find('./memberCode')
+
+            if member_class is None or not member_class.text:
+                continue
+
+            if member_code is None or not member_code.text:
+                continue
+
+            member_data: MemberData = {
+                'member_class': member_class.text,
+                'member_code': member_code.text,
+            }
+
+            members_list.append(member_data)
+        return members_list

--- a/anonymizer_module/metrics_statistics/postgresql_manager.py
+++ b/anonymizer_module/metrics_statistics/postgresql_manager.py
@@ -39,6 +39,7 @@ class StatisticalData(RequestsCountData):
     member_gov_count: int
     member_com_count: int
     member_org_count: int
+    services_request_counts: str
 
 
 METRICS_STATISTICS_SCHEMA: Dict[str, MetricsStatisticsField] = {
@@ -81,11 +82,35 @@ METRICS_STATISTICS_SCHEMA: Dict[str, MetricsStatisticsField] = {
     'member_org_count': {
         'type': 'integer',
         'index': False,
+    },
+    'services_request_counts': {
+        'type': 'json',
+        'index': False
     }
 }
 
 
-class PostgreSqlManager:
+class BasePostgreSQL_Manager:
+    def __init__(self, settings: dict):
+        self._settings = settings
+        self._connection_string = self._get_connection_string()
+        self._connect_args = {
+            'sslmode': settings.get('ssl-mode'),
+            'sslrootcert': settings.get('ssl-root-cert')
+        }
+
+    def _get_connection_string(self) -> str:
+        args = [
+            f"host={self._settings['host']}",
+            f"dbname={self._settings['database-name']}"
+        ]
+
+        optional_settings = {key: self._settings.get(key) for key in ['port', 'user', 'password']}
+        optional_args = [f'{key}={value}' if value else '' for key, value in optional_settings.items()]
+        return ' '.join(args + optional_args)
+
+
+class PostgreSQL_StatisticsManager(BasePostgreSQL_Manager):
 
     def __init__(self, postgres_settings: dict, logger: Logger) -> None:
         self._logger = logger
@@ -93,14 +118,11 @@ class PostgreSqlManager:
         self._table_name = METRICS_STATISTICS_TABLE
         self._readonly_users = postgres_settings['readonly-users']
         self._connection_string = self._get_connection_string()
-        self._connect_args = {
-            'sslmode': postgres_settings.get('ssl-mode'),
-            'sslrootcert': postgres_settings.get('ssl-root-cert')
-        }
 
-        table_schema = PostgreSqlManager.get_schema()
-        index_columns = PostgreSqlManager.get_indices()
+        table_schema = PostgreSQL_StatisticsManager.get_schema()
+        index_columns = PostgreSQL_StatisticsManager.get_indices()
         self._field_order = [field_name for field_name, _ in table_schema]
+        super().__init__(self._settings)
         if table_schema:
             self._ensure_table(table_schema, index_columns)
             self._ensure_privileges()
@@ -216,13 +238,16 @@ class PostgreSqlManager:
                                    + f' existence with connection {self._connection_string}. ERROR: {str(e)}')
             raise
 
-    def _get_connection_string(self) -> str:
-        args = [
-            f"host={self._settings['host']}",
-            f"dbname={self._settings['database-name']}"
-        ]
 
-        optional_settings = {key: self._settings.get(key) for key in ['port', 'user', 'password']}
-        optional_args = [f'{key}={value}' if value else '' for key, value in optional_settings.items()]
+class PostgreSQL_LogManager(BasePostgreSQL_Manager):
+    def __init__(self, postgres_settings: dict, logger: Logger):
+        self._logger = logger
+        self._table_name = postgres_settings['table-name']
+        super().__init__(postgres_settings)
 
-        return ' '.join(args + optional_args)
+    def get_services(self) -> List[str]:
+        with pg.connect(self._connection_string, **self._connect_args) as connection:
+            cursor = connection.cursor()
+            cursor.execute('SELECT servicesubsystemcode FROM {table_name} GROUP BY servicesubsystemcode;'.format(**{'table_name': self._table_name}))
+            data = cursor.fetchall()
+            return [service[0] for service in data if service[0]]

--- a/anonymizer_module/metrics_statistics/postgresql_manager.py
+++ b/anonymizer_module/metrics_statistics/postgresql_manager.py
@@ -39,6 +39,7 @@ class StatisticalData(RequestsCountData):
     member_gov_count: int
     member_com_count: int
     member_org_count: int
+    service_count: int
     services_request_counts: str
 
 
@@ -80,6 +81,10 @@ METRICS_STATISTICS_SCHEMA: Dict[str, MetricsStatisticsField] = {
         'index': False,
     },
     'member_org_count': {
+        'type': 'integer',
+        'index': False,
+    },
+    'service_count': {
         'type': 'integer',
         'index': False,
     },

--- a/anonymizer_module/metrics_statistics/postgresql_manager.py
+++ b/anonymizer_module/metrics_statistics/postgresql_manager.py
@@ -35,6 +35,12 @@ class MetricsStatisticsField(TypedDict):
     index: Optional[bool]
 
 
+class StatisticalData(RequestsCountData):
+    member_gov_count: int
+    member_com_count: int
+    member_org_count: int
+
+
 METRICS_STATISTICS_SCHEMA: Dict[str, MetricsStatisticsField] = {
     'update_time': {
         'type': 'timestamp',
@@ -63,6 +69,18 @@ METRICS_STATISTICS_SCHEMA: Dict[str, MetricsStatisticsField] = {
     'today_request_count': {
         'type': 'integer',
         'index': True
+    },
+    'member_gov_count': {
+        'type': 'integer',
+        'index': False,
+    },
+    'member_com_count': {
+        'type': 'integer',
+        'index': False,
+    },
+    'member_org_count': {
+        'type': 'integer',
+        'index': False,
     }
 }
 
@@ -103,7 +121,7 @@ class PostgreSqlManager:
             if field_data.get('index')
         ]
 
-    def add_statistics(self, data: RequestsCountData) -> None:
+    def add_statistics(self, data: StatisticalData) -> None:
         try:
             data['update_time'] = datetime.now()
             with pg.connect(self._connection_string, **self._connect_args) as connection:
@@ -115,7 +133,7 @@ class PostgreSqlManager:
             self._logger.exception(f'statistics_insertion_failed. Failed to insert statistics to postgres. ERROR: {str(e)}')
             raise
 
-    def _generate_insert_query(self, cursor: pg.extensions.cursor, data: RequestsCountData) -> str:
+    def _generate_insert_query(self, cursor: pg.extensions.cursor, data: StatisticalData) -> str:
         column_names = ','.join(self._field_order)
         template = '({})'.format(','.join(['%s'] * len(self._field_order)))
 

--- a/anonymizer_module/metrics_statistics/statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/statistics_manager.py
@@ -1,10 +1,11 @@
+import json
 from logging import Logger
 from pprint import pformat
 
 from metrics_statistics.central_server_client import CentralServerClient
 from metrics_statistics.mongodb_manager import DatabaseManager
-from metrics_statistics.postgresql_manager import (PostgreSqlManager,
-                                                   StatisticalData)
+from metrics_statistics.postgresql_manager import (
+    PostgreSQL_LogManager, PostgreSQL_StatisticsManager, StatisticalData)
 
 
 def collect_statistics(settings: dict, logger: Logger, output_only: bool = False) -> None:
@@ -23,14 +24,24 @@ def collect_statistics(settings: dict, logger: Logger, output_only: bool = False
     logger.info('Metrics statistics data: starting aggregate')
 
     database_manager = DatabaseManager(settings['mongodb'], settings['xroad']['instance'], logger)
-    pg_manager = PostgreSqlManager(settings['postgres'], logger)
+    pg_statistics_manager = PostgreSQL_StatisticsManager(settings['postgres'], logger)
+    pg_log_manager = PostgreSQL_LogManager(settings['postgres'], logger)
     cs_client = CentralServerClient(settings['xroad'], logger)
+
     member_counts = cs_client.get_member_count()
     requests_counts = database_manager.get_requests_counts()
-    statistics: StatisticalData = {**member_counts, **requests_counts}
+    services = pg_log_manager.get_services()
+    max_services_by_requests = settings.get('metrics-statistics', {}).get('num-max-services-requests', 5)
+    services_counts = database_manager.get_services_counts(services, max_services_by_requests)
+
+    statistics: StatisticalData = {
+        **member_counts,
+        **requests_counts,
+        **{'services_request_counts': json.dumps(services_counts)}
+    }
     if output_only:
         logger.info('Metrics statistical data:\n\n%s', pformat(statistics, indent=2, width=2))
     else:
-        pg_manager.add_statistics(statistics)
+        pg_statistics_manager.add_statistics(statistics)
         logger.info('Metrics statistics data: saved to database successfully. '
                     f"Total requests counted: {requests_counts['total_request_count']}")

--- a/anonymizer_module/metrics_statistics/statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/statistics_manager.py
@@ -37,6 +37,7 @@ def collect_statistics(settings: dict, logger: Logger, output_only: bool = False
     statistics: StatisticalData = {
         **member_counts,
         **requests_counts,
+        **{'service_count': len(services)},
         **{'services_request_counts': json.dumps(services_counts)}
     }
     if output_only:

--- a/anonymizer_module/metrics_statistics/statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/statistics_manager.py
@@ -1,8 +1,10 @@
 from logging import Logger
 from pprint import pformat
 
+from metrics_statistics.central_server_client import CentralServerClient
 from metrics_statistics.mongodb_manager import DatabaseManager
-from metrics_statistics.postgresql_manager import PostgreSqlManager
+from metrics_statistics.postgresql_manager import (PostgreSqlManager,
+                                                   StatisticalData)
 
 
 def collect_statistics(settings: dict, logger: Logger, output_only: bool = False) -> None:
@@ -22,10 +24,13 @@ def collect_statistics(settings: dict, logger: Logger, output_only: bool = False
 
     database_manager = DatabaseManager(settings['mongodb'], settings['xroad']['instance'], logger)
     pg_manager = PostgreSqlManager(settings['postgres'], logger)
+    cs_client = CentralServerClient(settings['xroad'], logger)
+    member_counts = cs_client.get_member_count()
     requests_counts = database_manager.get_requests_counts()
+    statistics: StatisticalData = {**member_counts, **requests_counts}
     if output_only:
-        logger.info('Metrics statistical data:\n\n%s', pformat(requests_counts, indent=2, width=2))
+        logger.info('Metrics statistical data:\n\n%s', pformat(statistics, indent=2, width=2))
     else:
-        pg_manager.add_statistics(requests_counts)
+        pg_manager.add_statistics(statistics)
         logger.info('Metrics statistics data: saved to database successfully. '
                     f"Total requests counted: {requests_counts['total_request_count']}")

--- a/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
@@ -1,6 +1,7 @@
-from datetime import datetime
 import logging
 import sqlite3
+from datetime import datetime
+from typing import Union
 
 import pytest
 from freezegun import freeze_time
@@ -26,8 +27,6 @@ MOCK_MEMBERS = [
         'member_class': 'ORG',
         'member_code': ''
     },
-
-
 ]
 
 TEST_SETTINGS = {
@@ -56,8 +55,104 @@ TEST_SETTINGS = {
         'user': 'test-user',
         'password': 'test-password',
         'host': 'test host'
+    },
+    'metrics-statistics': {
     }
 }
+
+
+def log_factory(db_session: sqlite3.Cursor,
+                request_in_dt: Union[str, datetime, None] = None, **kwargs) -> None:
+    overrides: dict = {}
+    overrides.update(**kwargs)
+    if request_in_dt:
+        if isinstance(request_in_dt, str):
+            forma = '%Y-%m-%dT%H:%M:%S'
+            request_in_dt = datetime.strptime(request_in_dt, forma)
+        request_in_ts = int(request_in_dt.timestamp() * 1000)
+        overrides.update(
+            {
+                'requestints': request_in_ts,
+                'requestindate': request_in_dt.strftime('%Y-%m-%d')
+            }
+        )
+
+    make_log(db_session, **overrides)
+
+
+def make_log(db_session, **kwargs):
+    defaults = {
+        'id': 0,
+        'requestints': 1667854800000,
+        'clientmemberclass': 'ORG',
+        'clientmembercode': '2908758-4',
+        'clientsubsystemcode': 'MonitoringClient',
+        'clientxroadinstance': 'TEST',
+        'messageid': 'ce724af7-b2cf-4a3d-a60f-0979578b1434',
+        'messageprotocolversion': '4.0',
+        'producerdurationproducerview': '',
+        'representedpartyclass': '',
+        'representedpartycode': '',
+        'requestattachmentcount': 0,
+        'requestindate': '2022-11-07',
+        'requestmimesize': 1089,
+        'requestsize': 0,
+        'responseattachmentcount': 2439,
+        'responsemimesize': '',
+        'responsesize': '2439',
+        'securityservertype': 'Client',
+        'servicecode': 'listMethods',
+        'servicememberclass': 'ORG',
+        'servicemembercode': '2908758-4',
+        'servicesubsystemcode': 'Management',
+        'servicetype': 'WSDL',
+        'serviceversion': '',
+        'servicexroadinstance': 'TEST',
+        'succeeded': 'TRUE',
+        'totalduration': 469
+    }
+    defaults.update(**kwargs)
+    db_session.execute(
+        """INSERT INTO LOGS(
+        id, requestints, clientmemberclass, clientmembercode, clientsubsystemcode, clientxroadinstance, messageid,
+        messageprotocolversion, producerdurationproducerview, representedpartyclass, representedpartycode,
+       requestattachmentcount, requestindate, requestints, requestmimesize, requestsize, responseattachmentcount,
+       responsemimesize, responsesize, securityservertype, servicecode, servicememberclass, servicemembercode,
+        servicesubsystemcode, servicetype, serviceversion, servicexroadinstance, succeeded, totalduration
+        )
+        VALUES(
+        :id,
+        :requestints,
+        :clientmemberclass,
+        :clientmembercode,
+        :clientsubsystemcode,
+        :clientxroadinstance,
+        :messageid,
+        :messageprotocolversion,
+        :producerdurationproducerview,
+        :representedpartyclass,
+        :representedpartycode,
+        :requestattachmentcount,
+        :requestindate,
+        :requestints,
+        :requestmimesize,
+        :requestsize,
+        :responseattachmentcount,
+       :responsemimesize,
+       :responsesize,
+       :securityservertype,
+       :servicecode,
+       :servicememberclass,
+       :servicemembercode,
+       :servicesubsystemcode,
+       :servicetype,
+       :serviceversion,
+       :servicexroadinstance,
+       :succeeded,
+       :totalduration
+        )""",
+        defaults
+    )
 
 
 class MockPsyContextManager:
@@ -109,8 +204,8 @@ class MockSQLiteCursor(object):
 
 @pytest.fixture
 def pg(mocker):
-    mocker.patch('metrics_statistics.postgresql_manager.PostgreSqlManager._ensure_table')
-    mocker.patch('metrics_statistics.postgresql_manager.PostgreSqlManager._ensure_privileges')
+    mocker.patch('metrics_statistics.postgresql_manager.PostgreSQL_StatisticsManager._ensure_table')
+    mocker.patch('metrics_statistics.postgresql_manager.PostgreSQL_StatisticsManager._ensure_privileges')
     connection = sqlite3.connect(':memory:', detect_types=sqlite3.PARSE_COLNAMES)
     db_session = connection.cursor()
     db_session.row_factory = sqlite3.Row
@@ -127,8 +222,39 @@ def pg(mocker):
         member_gov_count integer,
         member_com_count integer,
         member_org_count integer,
+        services_request_counts json,
         update_time timestamp);
     """)
+    db_session.execute("""CREATE TABLE logs (
+        id integer NOT NULL,
+        clientmemberclass character varying(255),
+        clientmembercode character varying(255),
+        clientsubsystemcode character varying(255),
+        clientxroadinstance character varying(255),
+        messageid character varying(255),
+        messageprotocolversion character varying(255),
+        producerdurationproducerview integer,
+        representedpartyclass character varying(255),
+        representedpartycode character varying(255),
+        requestattachmentcount integer,
+        requestindate date,
+        requestints bigint,
+        requestmimesize bigint,
+        requestsize bigint,
+        responseattachmentcount integer,
+        responsemimesize bigint,
+        responsesize bigint,
+        securityservertype character varying(255),
+        servicecode character varying(255),
+        servicememberclass character varying(255),
+        servicemembercode character varying(255),
+        servicesubsystemcode character varying(255),
+        servicetype character varying(255),
+        serviceversion character varying(255),
+        servicexroadinstance character varying(255),
+        succeeded boolean,
+        totalduration integer
+    );""")
     mocker.patch(
         'psycopg2.connect',
         return_value=MockPsyContextManager(MockSQLiteCursor(db_session))
@@ -143,7 +269,14 @@ def test_statistics_collector(pg, mocker):
         'metrics_statistics.central_server_client.CentralServerClient.get_members',
         return_value=MOCK_MEMBERS
     )
-    mock_statistics = {
+    make_log(pg, servicesubsystemcode='TestSerive1')
+    make_log(pg, servicesubsystemcode='TestSerive1')
+    make_log(pg, servicesubsystemcode='TestSerive2')
+    make_log(pg, servicesubsystemcode='TestSerive3')
+    make_log(pg, servicesubsystemcode='TestSerive4')
+    make_log(pg, servicesubsystemcode='TestSerive5')
+
+    mock_time_range_requests_counts = {
         'current_month_request_count': 100,
         'current_year_request_count': 2000,
         'previous_month_request_count': 1111,
@@ -153,8 +286,21 @@ def test_statistics_collector(pg, mocker):
     }
     mocker.patch(
         'metrics_statistics.mongodb_manager.DatabaseManager.get_requests_counts',
-        return_value=mock_statistics
+        return_value=mock_time_range_requests_counts
     )
+    mock_services_requests_counts = [{
+        'service_testservice1': [{'count': 10}],
+        'service_testservice2': [{'count': 8}],
+        'service_testservice3': [{'count': 25}],
+        'service_testservice4': [{'count': 3}],
+        'service_testservice5': [{'count': 1}],
+    }]
+    mocker.patch(
+        'metrics_statistics.mongodb_manager.DatabaseManager._get_db_service_request_counts',
+        return_value=mock_services_requests_counts
+    )
+    TEST_SETTINGS['metrics-statistics']['num-max-services-requests'] = 3
+
     collect_statistics(TEST_SETTINGS, logger)
     cursor = pg.execute('SELECT * FROM metrics_statistics')
     rows = cursor.fetchall()
@@ -171,5 +317,6 @@ def test_statistics_collector(pg, mocker):
         'member_gov_count': 1,
         'member_com_count': 2,
         'member_org_count': 0,
+        'services_request_counts': '{"service_testservice3": 25, "service_testservice1": 10, "service_testservice2": 8}',
         'update_time': '2022-12-10 00:00:00'
     }

--- a/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
@@ -9,6 +9,27 @@ from metrics_statistics.statistics_manager import collect_statistics
 
 logger = logging.getLogger()
 
+MOCK_MEMBERS = [
+    {
+        'member_class': 'COM',
+        'member_code': '234567-8'
+    },
+    {
+        'member_class': 'COM',
+        'member_code': '999999-1'
+    },
+    {
+        'member_class': 'GOV',
+        'member_code': '876543-2'
+    },
+    {
+        'member_class': 'ORG',
+        'member_code': ''
+    },
+
+
+]
+
 TEST_SETTINGS = {
     'logger': {
         'name': 'test',
@@ -18,7 +39,12 @@ TEST_SETTINGS = {
         'heartbeat-path': 'test',
     },
     'xroad': {
-        'instance': 'TEST'
+        'instance': 'TEST',
+        'central-server': {
+            'host': 'test',
+            'protocol': 'test',
+            'timeout': 0,
+        }
     },
     'postgres': {
         'table-name': 'logs',
@@ -98,6 +124,9 @@ def pg(mocker):
         previous_year_request_count integer,
         today_request_count integer,
         total_request_count integer,
+        member_gov_count integer,
+        member_com_count integer,
+        member_org_count integer,
         update_time timestamp);
     """)
     mocker.patch(
@@ -110,6 +139,10 @@ def pg(mocker):
 
 @freeze_time('2022-12-10')
 def test_statistics_collector(pg, mocker):
+    mocker.patch(
+        'metrics_statistics.central_server_client.CentralServerClient.get_members',
+        return_value=MOCK_MEMBERS
+    )
     mock_statistics = {
         'current_month_request_count': 100,
         'current_year_request_count': 2000,
@@ -135,5 +168,8 @@ def test_statistics_collector(pg, mocker):
         'previous_year_request_count': 4000,
         'today_request_count': 10,
         'total_request_count': 100000,
+        'member_gov_count': 1,
+        'member_com_count': 2,
+        'member_org_count': 0,
         'update_time': '2022-12-10 00:00:00'
     }

--- a/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
@@ -222,6 +222,7 @@ def pg(mocker):
         member_gov_count integer,
         member_com_count integer,
         member_org_count integer,
+        service_count integer,
         services_request_counts json,
         update_time timestamp);
     """)
@@ -317,6 +318,7 @@ def test_statistics_collector(pg, mocker):
         'member_gov_count': 1,
         'member_com_count': 2,
         'member_org_count': 0,
+        'service_count': 5,
         'services_request_counts': '{"service_testservice3": 25, "service_testservice1": 10, "service_testservice2": 8}',
         'update_time': '2022-12-10 00:00:00'
     }

--- a/anonymizer_module/test_requirements.txt
+++ b/anonymizer_module/test_requirements.txt
@@ -8,4 +8,5 @@ mypy
 pymongo-stubs
 freezegun
 pyyaml
+requests
 


### PR DESCRIPTION
1.  Count member classes: `member_gov_count`, `member_com_count` and `member_org_count`. - taken from global configuration. This configuration comes from security server.
2. Count services. List of unique services taken from `LOGS`  and strored in PG as `service_count`.
3. Count service requests in MongoDB and strore as `services_request_counts` JSON field.   List of service count can be limited by `settings['metrics-statistics'][num-max-services-requests]`. List of service counts is sorted by counts.