### PR TITLE
[OPMONDEV-179]:  make member count data a dynamic value

### DIFF
--- a/anonymizer_module/metrics_statistics/postgresql_manager.py
+++ b/anonymizer_module/metrics_statistics/postgresql_manager.py
@@ -36,11 +36,9 @@ class MetricsStatisticsField(TypedDict):
 
 
 class StatisticalData(RequestsCountData):
-    member_gov_count: int
-    member_com_count: int
-    member_org_count: int
+    member_count: str
     service_count: int
-    services_request_counts: str
+    service_request_count: str
 
 
 METRICS_STATISTICS_SCHEMA: Dict[str, MetricsStatisticsField] = {
@@ -72,23 +70,15 @@ METRICS_STATISTICS_SCHEMA: Dict[str, MetricsStatisticsField] = {
         'type': 'integer',
         'index': True
     },
-    'member_gov_count': {
-        'type': 'integer',
-        'index': False,
-    },
-    'member_com_count': {
-        'type': 'integer',
-        'index': False,
-    },
-    'member_org_count': {
-        'type': 'integer',
+    'member_count': {
+        'type': 'json',
         'index': False,
     },
     'service_count': {
         'type': 'integer',
         'index': False,
     },
-    'services_request_counts': {
+    'service_request_count': {
         'type': 'json',
         'index': False
     }

--- a/anonymizer_module/metrics_statistics/statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/statistics_manager.py
@@ -28,17 +28,18 @@ def collect_statistics(settings: dict, logger: Logger, output_only: bool = False
     pg_log_manager = PostgreSQL_LogManager(settings['postgres'], logger)
     cs_client = CentralServerClient(settings['xroad'], logger)
 
-    member_counts = cs_client.get_member_count()
+    members_in_config = cs_client.get_members_in_config()
+    member_counts = cs_client.get_member_count(members_in_config)
     requests_counts = database_manager.get_requests_counts()
     services = pg_log_manager.get_services()
     max_services_by_requests = settings.get('metrics-statistics', {}).get('num-max-services-requests', 5)
     services_counts = database_manager.get_services_counts(services, max_services_by_requests)
 
     statistics: StatisticalData = {
-        **member_counts,
         **requests_counts,
+        **{'member_count': json.dumps(member_counts)},
         **{'service_count': len(services)},
-        **{'services_request_counts': json.dumps(services_counts)}
+        **{'service_request_count': json.dumps(services_counts)}
     }
     if output_only:
         logger.info('Metrics statistical data:\n\n%s', pformat(statistics, indent=2, width=2))

--- a/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
@@ -297,12 +297,12 @@ def test_statistics_collector(pg, mocker):
         'metrics_statistics.central_server_client.CentralServerClient.get_members',
         return_value=MOCK_MEMBERS
     )
-    make_log(pg, servicesubsystemcode='TestSerive1')
-    make_log(pg, servicesubsystemcode='TestSerive1')
-    make_log(pg, servicesubsystemcode='TestSerive2')
-    make_log(pg, servicesubsystemcode='TestSerive3')
-    make_log(pg, servicesubsystemcode='TestSerive4')
-    make_log(pg, servicesubsystemcode='TestSerive5')
+    make_log(pg, servicesubsystemcode='TestService1')
+    make_log(pg, servicesubsystemcode='TestService1')
+    make_log(pg, servicesubsystemcode='TestService2')
+    make_log(pg, servicesubsystemcode='TestService3')
+    make_log(pg, servicesubsystemcode='TestService4')
+    make_log(pg, servicesubsystemcode='TestService5')
 
     mock_time_range_requests_counts = {
         'current_month_request_count': 100,
@@ -348,6 +348,10 @@ def test_statistics_collector(pg, mocker):
             {'class_name': 'ORG', 'description': 'Test organizations', 'count': 0},
             {'class_name': 'UNUSED', 'description': 'Just for test', 'count': 0}]),
         'service_count': 5,
-        'service_request_count': '{"service_testservice3": 25, "service_testservice1": 10, "service_testservice2": 8}',
+        'service_request_count': json.dumps([
+            {'title': 'TestService1', 'count': 10},
+            {'title': 'TestService2', 'count': 8},
+            {'title': 'TestService3', 'count': 25}
+        ]),
         'update_time': '2022-12-10 00:00:00'
     }

--- a/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
+++ b/anonymizer_module/metrics_statistics/tests/test_statistics_manager.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sqlite3
 from datetime import datetime
@@ -9,6 +10,26 @@ from freezegun import freeze_time
 from metrics_statistics.statistics_manager import collect_statistics
 
 logger = logging.getLogger()
+
+MOCK_CONFIG_MEMBERS = [
+    {
+        'class_name': 'COM',
+        'description': 'Test companies'
+    },
+    {
+        'class_name': 'GOV',
+        'description': 'Test govermental entities'
+    },
+    {
+        'class_name': 'ORG',
+        'description': 'Test organizations'
+    },
+    {
+        'class_name': 'UNUSED',
+        'description': 'Just for test'
+    },
+
+]
 
 MOCK_MEMBERS = [
     {
@@ -27,6 +48,10 @@ MOCK_MEMBERS = [
         'member_class': 'ORG',
         'member_code': ''
     },
+    {
+        'member_class': 'ORPHAN',
+        'member_code': 'ABCD-1234'
+    }
 ]
 
 TEST_SETTINGS = {
@@ -219,11 +244,9 @@ def pg(mocker):
         previous_year_request_count integer,
         today_request_count integer,
         total_request_count integer,
-        member_gov_count integer,
-        member_com_count integer,
-        member_org_count integer,
+        member_count json,
         service_count integer,
-        services_request_counts json,
+        service_request_count json,
         update_time timestamp);
     """)
     db_session.execute("""CREATE TABLE logs (
@@ -266,6 +289,10 @@ def pg(mocker):
 
 @freeze_time('2022-12-10')
 def test_statistics_collector(pg, mocker):
+    mocker.patch(
+        'metrics_statistics.central_server_client.CentralServerClient.get_members_in_config',
+        return_value=MOCK_CONFIG_MEMBERS
+    )
     mocker.patch(
         'metrics_statistics.central_server_client.CentralServerClient.get_members',
         return_value=MOCK_MEMBERS
@@ -315,10 +342,12 @@ def test_statistics_collector(pg, mocker):
         'previous_year_request_count': 4000,
         'today_request_count': 10,
         'total_request_count': 100000,
-        'member_gov_count': 1,
-        'member_com_count': 2,
-        'member_org_count': 0,
+        'member_count': json.dumps([
+            {'class_name': 'COM', 'description': 'Test companies', 'count': 2},
+            {'class_name': 'GOV', 'description': 'Test govermental entities', 'count': 1},
+            {'class_name': 'ORG', 'description': 'Test organizations', 'count': 0},
+            {'class_name': 'UNUSED', 'description': 'Just for test', 'count': 0}]),
         'service_count': 5,
-        'services_request_counts': '{"service_testservice3": 25, "service_testservice1": 10, "service_testservice2": 8}',
+        'service_request_count': '{"service_testservice3": 25, "service_testservice1": 10, "service_testservice2": 8}',
         'update_time': '2022-12-10 00:00:00'
     }

--- a/opendata_module/opmon_opendata/api/postgresql_manager.py
+++ b/opendata_module/opmon_opendata/api/postgresql_manager.py
@@ -244,11 +244,9 @@ class PostgreSQL_StatisticsManager(BasePostgreSQL_Manager):
                     today_request_count,
                     total_request_count,
                     update_time,
-                    member_gov_count,
-                    member_com_count,
-                    member_org_count,
+                    member_count,
                     service_count,
-                    services_request_counts
+                    service_request_count
                     FROM {table_name}
                     WHERE update_time = (SELECT MAX(update_time)
                 FROM {table_name})'''.format(**{'table_name': self._table_name})
@@ -262,9 +260,7 @@ class PostgreSQL_StatisticsManager(BasePostgreSQL_Manager):
             'today_request_count': row[4],
             'total_request_count': row[5],
             'update_time': row[6],
-            'member_gov_count': row[7],
-            'member_com_count': row[8],
-            'member_org_count': row[9],
-            'service_count': row[10],
-            'services_request_counts': row[11]
+            'member_count': row[7],
+            'service_count': row[8],
+            'service_request_count': row[9]
         } if row else None

--- a/opendata_module/opmon_opendata/api/views.py
+++ b/opendata_module/opmon_opendata/api/views.py
@@ -329,11 +329,9 @@ def get_statistics_data(request: WSGIRequest, profile: Optional[str] = None) -> 
         'previous_year_request_count': statistics['previous_year_request_count'],
         'today_request_count': statistics['today_request_count'],
         'total_request_count': statistics['total_request_count'],
-        'member_gov_count': statistics['member_gov_count'],
-        'member_com_count': statistics['member_com_count'],
-        'member_org_count': statistics['member_org_count'],
+        'member_count': statistics['member_count'],
         'service_count': statistics['service_count'],
-        'services_request_counts': statistics['services_request_counts'],
+        'service_request_count': statistics['service_request_count'],
         'update_time': statistics['update_time'].strftime('%Y-%m-%dT%H:%M:%S')
     }
     return HttpResponse(

--- a/opendata_module/opmon_opendata/tests/test_api.py
+++ b/opendata_module/opmon_opendata/tests/test_api.py
@@ -422,7 +422,11 @@ def test_get_harvest_error_unsupported_method(http_client):
 
 @freeze_time('2022-12-10')
 def test_get_statistics_data_success(db, http_client, caplog):
-    test_service_counts = {'service_test1': 60, 'service_test2': 50}
+    test_member_count = [
+        {'class_name': 'COM', 'description': 'Test companies', 'count': 2},
+        {'class_name': 'GOV', 'description': 'Test govermental entities', 'count': 1},
+    ]
+    test_service_count = {'service_test1': 60, 'service_test2': 50}
     make_m_statistics(db, **{
         'current_month_request_count': 3742,
         'current_year_request_count': 4648,
@@ -430,11 +434,9 @@ def test_get_statistics_data_success(db, http_client, caplog):
         'previous_year_request_count': 0,
         'today_request_count': 0,
         'total_request_count': 4648,
-        'member_gov_count': 10,
-        'member_com_count': 20,
-        'member_org_count': 30,
+        'member_count': json.dumps(test_member_count),
         'service_count': 50,
-        'services_request_counts': json.dumps(test_service_counts),
+        'service_request_count': json.dumps(test_service_count),
     })
     response = http_client.get('/api/statistics')
     assert response.status_code == 200
@@ -445,11 +447,9 @@ def test_get_statistics_data_success(db, http_client, caplog):
         'previous_year_request_count': 0,
         'today_request_count': 0,
         'total_request_count': 4648,
-        'member_gov_count': 10,
-        'member_com_count': 20,
-        'member_org_count': 30,
+        'member_count': json.dumps(test_member_count),
         'service_count': 50,
-        'services_request_counts': json.dumps(test_service_counts),
+        'service_request_count': json.dumps(test_service_count),
         'update_time': '2022-12-10T00:00:00'
     }
     assert 'Statistics data fetched successfully' in caplog.text

--- a/opendata_module/opmon_opendata/tests/test_utils.py
+++ b/opendata_module/opmon_opendata/tests/test_utils.py
@@ -228,11 +228,9 @@ def db(mocker):
         previous_year_request_count integer,
         today_request_count integer,
         total_request_count integer,
-        member_gov_count integer,
-        member_com_count integer,
-        member_org_count integer,
+        member_count json,
         service_count integer,
-        services_request_counts json,
+        service_request_count json,
         update_time timestamp);
     """)
     connection.commit()
@@ -284,11 +282,9 @@ def make_m_statistics(db_session, **kwargs):
                         previous_year_request_count,
                         today_request_count,
                         total_request_count,
-                        member_gov_count,
-                        member_com_count,
-                        member_org_count,
+                        member_count,
                         service_count,
-                        services_request_counts,
+                        service_request_count,
                         update_time
                     )
                     VALUES(
@@ -299,11 +295,9 @@ def make_m_statistics(db_session, **kwargs):
                         :previous_year_request_count,
                         :today_request_count,
                         :total_request_count,
-                        :member_gov_count,
-                        :member_com_count,
-                        :member_org_count,
+                        :member_count,
                         :service_count,
-                        :services_request_counts,
+                        :service_request_count,
                         :update_time
                     )
                     """,


### PR DESCRIPTION
As Petteri and Raido raised a question about member data being in dynamic nature and each instance may have own:

1. Use single `member_count` JSON field in PG to store dynamic result of count.
2. Take members from global configuration and count occurrences in member list
3. Store description of member class as well
4. Additionally unify service count data, stored in PG.
5. Change Opendata module API to return updated statistics structure.

At the end, data returned in Opendata  GET `api/statistics` looks correspondingly :
```
{
    "current_month_request_count": 18928,
    "current_year_request_count": 42099,
    "previous_month_request_count": 20174,
    "previous_year_request_count": 0,
    "today_request_count": 0,
    "total_request_count": 42099,
    "member_count": [
        {
            "class_name": "COM",
            "description": "Commercial",
            "count": 1
        },
        {
            "class_name": "GOV",
            "description": "Governmental",
            "count": 1
        },
        {
            "class_name": "ORG",
            "description": "Non-profit organizations, associations, institutes",
            "count": 1
        }
    ],
    "service_count": 5,
    "service_request_count": [
        {
            "title": "TestTopic",
            "count": 30
        },
        {
            "title": "DemoSystem",
            "count": 3
        },
        {
            "title": "TestClient",
            "count": 845
        },
        {
            "title": "Management",
            "count": 881
        },
        {
            "title": "TestService",
            "count": 966
        }
    ],
    "update_time": "2023-08-30T18:21:36"
}
```