### PR TITLE
chore: removed UI elements under the opendata module web interface that allowed setting the page size and searching in results as these are now supported in the API

### DIFF
--- a/opendata_module/opmon_opendata/static/gui/index.js
+++ b/opendata_module/opmon_opendata/static/gui/index.js
@@ -183,7 +183,9 @@ function displayPreview() {
             ajax: API_ROOT + '/logs_sample' + getQuery(),
             cache: false,
             scrollX: true,
-            ordering: false
+            ordering: false,
+            lengthChange: false,
+            searching: false,
         } );
     })
 }


### PR DESCRIPTION
By default, the jQuery [dataTables](https://datatables.net) library that we use in the `opendata` module shows UI elements that allow users to change the page size and also search. The API doesn't support either of those functionalities, so we are disabling them until we implement the new UI and decide what to do with it.

More information about the [options dataTables provide](https://datatables.net/reference/option/).