### PR TITLE
Fix duplicate logging

### DIFF
--- a/analysis_module/opmon_analyzer/logger_manager.py
+++ b/analysis_module/opmon_analyzer/logger_manager.py
@@ -58,7 +58,7 @@ class LoggerManager:
 
     def _handler_is_set(self, handlers):
         for handler in handlers:
-            if handler is WatchedFileHandler and os.path.abspath(self.log_path) == handler.baseFilename:
+            if isinstance(handler, WatchedFileHandler) and os.path.abspath(self.log_path) == handler.baseFilename:
                 return True
         return False
 

--- a/analysis_ui_module/opmon_analyzer_ui/logger_manager.py
+++ b/analysis_ui_module/opmon_analyzer_ui/logger_manager.py
@@ -58,7 +58,7 @@ class LoggerManager:
 
     def _handler_is_set(self, handlers):
         for handler in handlers:
-            if handler is WatchedFileHandler and os.path.abspath(self.log_path) == handler.baseFilename:
+            if isinstance(handler, WatchedFileHandler) and os.path.abspath(self.log_path) == handler.baseFilename:
                 return True
         return False
 

--- a/anonymizer_module/opmon_anonymizer/utils/logger_manager.py
+++ b/anonymizer_module/opmon_anonymizer/utils/logger_manager.py
@@ -58,7 +58,7 @@ class LoggerManager:
 
     def _handler_is_set(self, handlers):
         for handler in handlers:
-            if handler is WatchedFileHandler and os.path.abspath(self.log_path) == handler.baseFilename:
+            if isinstance(handler, WatchedFileHandler) and os.path.abspath(self.log_path) == handler.baseFilename:
                 return True
         return False
 

--- a/collector_module/opmon_collector/logger_manager.py
+++ b/collector_module/opmon_collector/logger_manager.py
@@ -58,7 +58,7 @@ class LoggerManager:
 
     def _handler_is_set(self, handlers):
         for handler in handlers:
-            if handler is WatchedFileHandler and os.path.abspath(self.log_path) == handler.baseFilename:
+            if isinstance(handler, WatchedFileHandler) and os.path.abspath(self.log_path) == handler.baseFilename:
                 return True
         return False
 

--- a/corrector_module/opmon_corrector/logger_manager.py
+++ b/corrector_module/opmon_corrector/logger_manager.py
@@ -58,7 +58,7 @@ class LoggerManager:
 
     def _handler_is_set(self, handlers):
         for handler in handlers:
-            if handler is WatchedFileHandler and os.path.abspath(self.log_path) == handler.baseFilename:
+            if isinstance(handler, WatchedFileHandler) and os.path.abspath(self.log_path) == handler.baseFilename:
                 return True
         return False
 

--- a/reports_module/opmon_reports/logger_manager.py
+++ b/reports_module/opmon_reports/logger_manager.py
@@ -58,7 +58,7 @@ class LoggerManager:
 
     def _handler_is_set(self, handlers):
         for handler in handlers:
-            if handler is WatchedFileHandler and os.path.abspath(self.log_path) == handler.baseFilename:
+            if isinstance(handler, WatchedFileHandler) and os.path.abspath(self.log_path) == handler.baseFilename:
                 return True
         return False
 


### PR DESCRIPTION
Currently check `handler is WatchedFileHandler` always fails and a new handler is added every time _setup_logger is called.

For example corrector logs every line three times.

A fix for opendata was added with pull request https://github.com/nordic-institute/X-Road-Metrics/pull/14

This commit makes the same change in all the other services.