### PR TITLE
Corrector optimization

### DIFF
--- a/corrector_module/opmon_corrector/corrector_batch.py
+++ b/corrector_module/opmon_corrector/corrector_batch.py
@@ -102,12 +102,10 @@ class CorrectorBatch:
         # Process documents with xRequestId
         doc_map = defaultdict(list)
         for _doc in cursor:
-            sanitised_doc = document_manager.DocumentManager.sanitise_document(_doc)
-            x_request_id = sanitised_doc.get('xRequestId')
+            x_request_id = _doc.get('xRequestId')
             if not x_request_id:
                 continue
-            fix_doc = doc_m.correct_structure(sanitised_doc)
-            doc_map[x_request_id].append(fix_doc)
+            doc_map[x_request_id].append(_doc)
 
         # Build queue to be processed
         list_to_process = multiprocessing.Queue()
@@ -155,7 +153,7 @@ class CorrectorBatch:
         self.logger_m.log_info('corrector_batch_raw', 'Processing {0} faulty raw documents'.format(len(cursor)))
 
         for _doc in cursor:
-            sanitised_doc = document_manager.DocumentManager.sanitise_document(_doc)
+            sanitised_doc = doc_m.sanitise_document(_doc)
             fixed_doc = doc_m.correct_structure(sanitised_doc)
             producer = fixed_doc if fixed_doc['securityServerType'].lower() == SECURITY_SERVER_TYPE_PRODUCER else None
             client = fixed_doc if fixed_doc['securityServerType'].lower() == SECURITY_SERVER_TYPE_CLIENT else None

--- a/corrector_module/opmon_corrector/corrector_batch.py
+++ b/corrector_module/opmon_corrector/corrector_batch.py
@@ -21,7 +21,6 @@
 #  THE SOFTWARE.
 
 import multiprocessing
-import queue
 import time
 from collections import defaultdict
 
@@ -53,11 +52,12 @@ class CorrectorBatch:
             # Raise exception again
             raise e
 
-    def _process_workers(self, list_to_process, duplicates):
+    def _process_workers(self, list_to_process, duplicates, job_type='consume'):
         """
         Processes the workers in a thread pool.
         :param list_to_process: queue of items to be processed by the worker processes
-        :param duplicates: a shared Value object to store the number of duplicates encountered during processing
+        :param duplicates: a shared Value object to store the number of duplicates encountered
+        during processing
         : return: None
         """
         # Configure worker
@@ -66,7 +66,7 @@ class CorrectorBatch:
             # Configure worker
             worker = CorrectorWorker(self.settings, f'worker_{i}')
             p = multiprocessing.Process(
-                target=worker.run, args=(list_to_process, duplicates)
+                target=worker.run, args=(list_to_process, duplicates, job_type)
             )
             pool.append(p)
 
@@ -79,9 +79,10 @@ class CorrectorBatch:
 
     def _batch_run(self, process_dict):
         """
-        Gets unique xRequestId's, gets documents by xRequestId, corrects documents, initializes workers,
-        gets raw documents, groups by "messageId", corrects documents' structure, initializes workers,
-        updates timeout documents to "done", removes duplicates from raw_messages.
+        Gets unique xRequestId's, gets documents by xRequestId, corrects documents, initializes
+        workers, gets raw documents, groups by "messageId", corrects documents' structure,
+        initializes workers, updates timeout documents to "done", removes duplicates from
+        raw_messages.
         :param process_dict:
         :return: Returns the amount of documents still to process.
         """
@@ -97,7 +98,7 @@ class CorrectorBatch:
 
         limit = self.settings['corrector']['documents-max']
         cursor = db_m.get_raw_documents(limit)
-        self.logger_m.log_info('corrector_batch_raw', 'Processing {0} raw documents'.format(len(cursor)))
+        self.logger_m.log_info('corrector_batch_raw', f'Processing {len(cursor)} raw documents.')
 
         # Process documents with xRequestId
         doc_map = defaultdict(list)
@@ -124,12 +125,13 @@ class CorrectorBatch:
         self._process_workers(list_to_process, duplicates)
 
         if duplicates.value > 0:
-            self.logger_m.log_info('corrector_batch_remove_duplicates_from_raw',
-                                   'Total of {0} duplicate documents removed from raw messages.'.format(
-                                       duplicates.value))
+            self.logger_m.log_info(
+                'corrector_batch_remove_duplicates_from_raw',
+                f'Total of {duplicates.value} duplicate documents removed from raw messages.')
         else:
-            self.logger_m.log_info('corrector_batch_remove_duplicates_from_raw',
-                                   'No raw documents marked to removal.')
+            self.logger_m.log_info(
+                'corrector_batch_remove_duplicates_from_raw',
+                'No raw documents marked to removal.')
 
         # Process documents without xRequestId
         cursor = db_m.get_faulty_raw_documents(limit)
@@ -152,38 +154,39 @@ class CorrectorBatch:
             db_m.add_to_clean_data(cleaned_document)
             db_m.mark_as_corrected(fixed_doc)
 
+        # Updating Status of older documents from processing to done
         timeout = self.settings['corrector']['timeout-days']
-        self.logger_m.log_info('corrector_batch_update_timeout',
-                               f'Updating timed out [{timeout} days] orphans to done.')
+        self.logger_m.log_info(
+            'corrector_batch_update_timeout',
+            f'Updating timed out [{timeout} days] orphans to done.')
 
-        # Update Status of older documents according to client.requestInTs
-        cursor = db_m.get_timeout_documents_client(timeout, limit=limit)
-        list_of_docs = list(cursor)
-        number_of_updated_docs = db_m.update_old_to_done(list_of_docs)
+        list_of_doc_ids_client = db_m.get_timeout_document_ids_client(timeout, limit=limit)
+        list_of_doc_ids_producer = db_m.get_timeout_document_ids_producer(timeout, limit=limit)
+        list_of_doc_ids = list_of_doc_ids_client + list_of_doc_ids_producer
+        if len(list_of_doc_ids) > 0:
+            doc_len += len(list_of_doc_ids)
+            list_to_process = multiprocessing.Queue()
+            for _doc in list_of_doc_ids:
+                list_to_process.put(_doc['_id'])
+            self._process_workers(list_to_process, None, 'timeout')
 
-        if number_of_updated_docs > 0:
-            self.logger_m.log_info('corrector_batch_update_client_old_to_done',
-                                   "Total of {0} orphans from Client updated to status 'done'.".format(
-                                       number_of_updated_docs))
+        if len(list_of_doc_ids_client) > 0:
+            self.logger_m.log_info(
+                'corrector_batch_update_client_old_to_done',
+                f'Total of {len(list_of_doc_ids_client)} orphans from Client '
+                "updated to status 'done'.")
         else:
-            self.logger_m.log_info('corrector_batch_update_client_old_to_done',
-                                   'No orphans updated to done.')
-        doc_len += number_of_updated_docs
+            self.logger_m.log_info(
+                'corrector_batch_update_client_old_to_done', 'No orphans updated to done.')
 
-        # Update Status of older documents according to producer.requestInTs
-        cursor = db_m.get_timeout_documents_producer(timeout, limit=limit)
-        list_of_docs = list(cursor)
-        number_of_updated_docs = db_m.update_old_to_done(list_of_docs)
-
-        if number_of_updated_docs > 0:
-            self.logger_m.log_info('corrector_batch_update_producer_old_to_done',
-                                   "Total of {0} orphans from Producer updated to status 'done'.".format(
-                                       number_of_updated_docs))
+        if len(list_of_doc_ids_producer) > 0:
+            self.logger_m.log_info(
+                'corrector_batch_update_producer_old_to_done',
+                f'Total of {len(list_of_doc_ids_producer)} orphans from Producer '
+                "updated to status 'done'.")
         else:
-            self.logger_m.log_info('corrector_batch_update_producer_old_to_done',
-                                   'No orphans updated to done.')
-
-        doc_len += number_of_updated_docs
+            self.logger_m.log_info(
+                'corrector_batch_update_producer_old_to_done', 'No orphans updated to done.')
 
         end_processing_time = time.time()
         total_time = time.strftime(

--- a/corrector_module/opmon_corrector/corrector_worker.py
+++ b/corrector_module/opmon_corrector/corrector_worker.py
@@ -80,10 +80,12 @@ class CorrectorWorker:
         ]
 
         if clients:
-            matched_pair['client'] = clients[0]
+            if not self.db_m.check_clean_document_exists(x_request_id, clients[0]):
+                matched_pair['client'] = clients[0]
 
         if producers:
-            matched_pair['producer'] = producers[0]
+            if not self.db_m.check_clean_document_exists(x_request_id, producers[0]):
+                matched_pair['producer'] = producers[0]
 
         docs_to_remove = [
             doc for doc in documents

--- a/corrector_module/opmon_corrector/corrector_worker.py
+++ b/corrector_module/opmon_corrector/corrector_worker.py
@@ -71,8 +71,8 @@ class CorrectorWorker:
         x_request_id = data['x_request_id']
         documents = []
         for _doc in data['documents']:
-            sanitised_doc = doc_m.sanitise_document(_doc)
-            fix_doc = doc_m.correct_structure(sanitised_doc)
+            sanitized_doc = doc_m.sanitize_document(_doc)
+            fix_doc = doc_m.correct_structure(sanitized_doc)
             documents.append(fix_doc)
         duplicates = 0
 
@@ -163,8 +163,8 @@ class CorrectorWorker:
         # Get parameters
         # logger_manager = data['logger_manager']
         doc_m = data['document_manager']
-        sanitised_doc = doc_m.sanitise_document(data['document'])
-        fixed_doc = doc_m.correct_structure(sanitised_doc)
+        sanitized_doc = doc_m.sanitize_document(data['document'])
+        fixed_doc = doc_m.correct_structure(sanitized_doc)
         producer = fixed_doc if (
             fixed_doc['securityServerType'].lower() == SECURITY_SERVER_TYPE_PRODUCER) else None
         client = fixed_doc if (

--- a/corrector_module/opmon_corrector/corrector_worker.py
+++ b/corrector_module/opmon_corrector/corrector_worker.py
@@ -1,4 +1,3 @@
-
 #  The MIT License
 #  Copyright (c) 2021- Nordic Institute for Interoperability Solutions (NIIS)
 #  Copyright (c) 2017-2020 Estonian Information System Authority (RIA)
@@ -63,7 +62,11 @@ class CorrectorWorker:
         logger_manager = data['logger_manager']
         doc_m = data['document_manager']
         x_request_id = data['x_request_id']
-        documents = data['documents']
+        documents = []
+        for _doc in data['documents']:
+            sanitised_doc = doc_m.sanitise_document(_doc)
+            fix_doc = doc_m.correct_structure(sanitised_doc)
+            documents.append(fix_doc)
         to_remove_queue = data['to_remove_queue']
         duplicates = no_requestInTs = 0
 

--- a/corrector_module/opmon_corrector/database_manager.py
+++ b/corrector_module/opmon_corrector/database_manager.py
@@ -157,12 +157,13 @@ class DatabaseManager:
             self.logger_m.log_exception('DatabaseManager.get_processing_documents', repr(e))
             raise e
 
-    def get_timeout_documents_client(self, timeout_days: int, limit: int = 1000) -> List[dict]:
+    def get_timeout_document_ids_client(self, timeout_days: int, limit: int = 1000) -> List[dict]:
         """
-        Gets the documents from Client that have been processing more than timeout_days.
+        Gets the document ids (without other fields) from Client that have been processing more
+        than timeout_days.
         :param timeout_days: The timeout days.
-        :param limit: Number of documents to return.
-        :return: Returns the documents that have been processing more than timeout_days.
+        :param limit: Number of document ids to return.
+        :return: Returns the document ids that have been processing more than timeout_days.
         """
         try:
             db = self.get_query_db()
@@ -173,18 +174,20 @@ class DatabaseManager:
                 'client.requestInTs': {'$lt': ref_time},
                 'client.xRequestId': {'$ne': None}
             }
-            cursor = clean_data.find(q).limit(limit)
+            cursor = clean_data.find(q, {'_id': True}).limit(limit)
             return list(cursor)
         except Exception as e:
-            self.logger_m.log_exception('DatabaseManager.get_timeout_documents_client', repr(e))
+            self.logger_m.log_exception(
+                'DatabaseManager.get_timeout_document_ids_client', repr(e))
             raise e
 
-    def get_timeout_documents_producer(self, timeout_days: int, limit: int = 1000) -> List[dict]:
+    def get_timeout_document_ids_producer(self, timeout_days: int, limit: int = 1000) -> List[dict]:
         """
-        Gets the documents from Producer that have been processing more than timeout_days.
+        Gets the document ids (without other fields) from Producer that have been processing more
+        than timeout_days.
         :param timeout_days: The timeout days.
-        :param limit: Number of documents to return.
-        :return: Returns the documents that have been processing more than timeout_days.
+        :param limit: Number of document ids to return.
+        :return: Returns the document ids that have been processing more than timeout_days.
         """
         try:
             db = self.get_query_db()
@@ -192,14 +195,17 @@ class DatabaseManager:
             ref_time = 1000 * (get_timestamp() - (timeout_days * 24 * 60 * 60))
             q = {
                 'correctorStatus': 'processing',
-                'client.requestInTs': {'$exists': False},
+                # This check does not seem to be necessary.
+                # Documents with both client and producer should never be in "processing" state.
+                # 'client.requestInTs': {'$exists': False},
                 'producer.requestInTs': {'$lt': ref_time},
                 'producer.xRequestId': {'$ne': None}
             }
-            cursor = clean_data.find(q).limit(limit)
+            cursor = clean_data.find(q, {'_id': True}).limit(limit)
             return list(cursor)
         except Exception as e:
-            self.logger_m.log_exception('DatabaseManager.get_timeout_documents_producer', repr(e))
+            self.logger_m.log_exception(
+                'DatabaseManager.get_timeout_document_ids_producer', repr(e))
             raise e
 
     def add_to_clean_data(self, document: dict) -> None:
@@ -231,26 +237,21 @@ class DatabaseManager:
             self.logger_m.log_exception('DatabaseManager.update_form_clean_data', repr(e))
             raise e
 
-    def update_old_to_done(self, list_of_docs: List[dict]) -> int:
+    def update_old_doc_to_done(self, doc_id: str) -> None:
         """
-        Updates then correctorStatus to "done" for the given list of documents. Also updates the correctorTime.
-        :param list_of_docs: The input list of documents to be updated.
-        :return: Number of documents updated.
+        Updates correctorStatus to "done" for the given document. Also updates the correctorTime.
+        :param doc_id: Document "_id" to be updated.
+        :return: None.
         """
-        number_of_updated_docs = 0
         try:
             db = self.get_query_db()
             clean_data = db[CLEAN_DATA_COLLECTION]
-            for doc in list_of_docs:
-                clean_data.update({'_id': doc['_id']},
-                                  {'$set': {'correctorStatus': 'done', 'correctorTime': get_timestamp()}})
-                number_of_updated_docs += 1
-
+            clean_data.update_one(
+                {'_id': doc_id},
+                {'$set': {'correctorStatus': 'done', 'correctorTime': get_timestamp()}})
         except Exception as e:
             self.logger_m.log_exception('DatabaseManager.update_old_to_done', repr(e))
             raise e
-
-        return number_of_updated_docs
 
     def check_clean_document_exists(self, x_request_id: str, document: dict) -> bool:
         """

--- a/corrector_module/opmon_corrector/document_manager.py
+++ b/corrector_module/opmon_corrector/document_manager.py
@@ -23,8 +23,6 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-import bleach
-
 from opmon_corrector import (SECURITY_SERVER_TYPE_CLIENT,
                              SECURITY_SERVER_TYPE_PRODUCER, __version__)
 from opmon_corrector.logger_manager import LoggerManager
@@ -309,17 +307,26 @@ class DocumentManager:
         }
 
     @staticmethod
-    def sanitise_document(document: dict) -> dict:
+    def escape_html(value: str) -> str:
         """
-        Sanitizes the document by cleaning string values using bleach if they are present.
-        :param document: The document to be sanitised.
-        :return: Returns the sanitised document.
+        Escape html to avoid potential XSS attacks during log processing.
+        :param value: The string to be escaped.
+        :return: Returns escaped string.
         """
-        sanitised_document = {
-            key: bleach.clean(value) if isinstance(value, str) else value
+        return value.translate(str.maketrans({'<': '&lt;', '>': '&gt;', '&': '&amp;'}))
+
+    @staticmethod
+    def sanitize_document(document: dict) -> dict:
+        """
+        Sanitizes the document by HTML escaping string values if they are present.
+        :param document: The document to be sanitized.
+        :return: Returns the sanitized document.
+        """
+        sanitized_document = {
+            key: DocumentManager.escape_html(value) if isinstance(value, str) else value
             for key, value in document.items()
         }
-        return sanitised_document
+        return sanitized_document
 
     def correct_structure(self, doc):
         """

--- a/corrector_module/opmon_corrector/tests/test_corrector_batch.py
+++ b/corrector_module/opmon_corrector/tests/test_corrector_batch.py
@@ -19,9 +19,9 @@ TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class SingleProcessedCorrectorBatch(CorrectorBatch):
-    def _process_workers(self, list_to_process, duplicates):
+    def _process_workers(self, list_to_process, duplicates, job_type='consume'):
         worker = CorrectorWorker(self.settings, 'worker 1')
-        worker.run(list_to_process, duplicates)
+        worker.run(list_to_process, duplicates, job_type)
 
 
 def read_data_from_json(path):

--- a/corrector_module/opmon_corrector/tests/test_document_manager.py
+++ b/corrector_module/opmon_corrector/tests/test_document_manager.py
@@ -530,9 +530,9 @@ def test_correct_structure(mock_logger_manager, basic_settings):
     assert all([v is None for v in doc.values()])
 
 
-def test_sanitise_document(mock_logger_manager, basic_settings):
+def test_sanitize_document(mock_logger_manager, basic_settings):
     dm = DocumentManager(basic_settings)
-    sanitised_doc = dm.sanitise_document({
+    sanitized_doc = dm.sanitize_document({
         'field1': '<img src/onerror=prompt(8)>',
         'field2': '</scrip</script>t><img src =q onerror=prompt(8)>',
         'field3': 100,
@@ -540,7 +540,7 @@ def test_sanitise_document(mock_logger_manager, basic_settings):
         'field5': None,
         'field6': {'sub': 'test'}
     })
-    assert sanitised_doc == {
+    assert sanitized_doc == {
         'field1': '&lt;img src/onerror=prompt(8)&gt;',
         'field2': '&lt;/scrip&lt;/script&gt;t&gt;&lt;img src =q onerror=prompt(8)&gt;',
         'field3': 100,

--- a/corrector_module/setup.py
+++ b/corrector_module/setup.py
@@ -27,8 +27,7 @@ from setuptools import setup
 requirements = [
     'setuptools==67.4.0',
     'pymongo==3.10.1',
-    'pyyaml==5.4.1',
-    'bleach==6.0.0'
+    'pyyaml==5.4.1'
 ]
 
 classifiers = [


### PR DESCRIPTION
Corrector is currently using multiprocessing only for raw data processing, and many tasks are preformed in a single main thread that can use only one CPU core and therefore negatively impact corrector throughput.

This pull request optimizes corrector to increase throughput. Additionally a check if processed document already exists in clean_data is added (this check existed before last corrector rewrite, but was broken since that time).

* Performing sanitise_document and correct_structure in worker threads instead of main thread.
* Deleting duplicates in threads instead of returning to_remove_queue and slowly processing that in main thread.
* Adding check if processed document already exists in clean_data (was broken after "matching of documents by xRequestId" commit).
* Using multiprocessing for updating status of orphans that reached timeout.
* Using multiprocessing for processing of documents without xRequestId.
* Optimizing document sanitizer (using translate method instead of slow and deprecated bleach.clean).
* Fixing calculation of total documents processed by corrector.