### PR TITLE
Adding support for CSV reports

### DIFF
--- a/reports_module/etc/settings.yaml
+++ b/reports_module/etc/settings.yaml
@@ -32,6 +32,9 @@ reports:
   # Generated report pdf-files will be stored in this path
   report-path: /var/lib/xroad-metrics/reports
 
+  # Additionally generate csv reports
+  # generate-csv: False
+
   # Language translation config files are stored in this path
   translation-path: /etc/xroad-metrics/reports/lang
 
@@ -73,6 +76,14 @@ reports:
 
 
       Report name: {REPORT_NAME}
+
+      Produced services (CSV): csv/{REPORT_NAME_NO_EXT}_prod_serv.csv
+
+      Produced metaservices (CSV): csv/{REPORT_NAME_NO_EXT}_prod_meta.csv
+
+      Consumed services (CSV): csv/{REPORT_NAME_NO_EXT}_cons_serv.csv
+
+      Consumed metaservices (CSV): csv/{REPORT_NAME_NO_EXT}_cons_meta.csv
 
       X-Road subsystem: {X_ROAD_INSTANCE}:{MEMBER_CLASS}:{MEMBER_CODE}:{SUBSYSTEM_CODE}
 

--- a/reports_module/opmon_reports/notification_manager.py
+++ b/reports_module/opmon_reports/notification_manager.py
@@ -20,6 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+import os
 import smtplib
 import ssl
 from typing import Iterable
@@ -85,7 +86,8 @@ class NotificationManager:
             'MEMBER_CODE': notification['member_code'],
             'SUBSYSTEM_CODE': notification['subsystem_code'],
             'START_DATE': notification['start_date'],
-            'END_DATE': notification['end_date']
+            'END_DATE': notification['end_date'],
+            'REPORT_NAME_NO_EXT': os.path.splitext(notification['report_name'])[0]
         }
 
         msg = MIMEText(self.settings['message'].format(


### PR DESCRIPTION
Some users want to process report data, but generated PDF is not machine-readable. CSV format on the other hand can be easily imported into spreadsheets or processed by other tools.

This pull request is adding:
* CSV generation support
* optional configuration parameter for CSV generation
* REPORT_NAME_NO_EXT variable for email template
