### PR TITLE
fix: Freeze pydyf's version in dependencies to fix reports during runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,9 @@ updates:
       - dependency-name: "pyparsing"
         versions:
           - ">= 3.2.0"
+      - dependency-name: "pydyf"
+        versions:
+          - ">= 0.11.0"
 
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"

--- a/reports_module/setup.py
+++ b/reports_module/setup.py
@@ -42,6 +42,7 @@ requirements = [
     'numpy==1.24.4',
     'contourpy==1.1.1',
     'pyparsing==3.1.4',
+    'pydyf==0.10.0',
 ]
 
 classifiers = [


### PR DESCRIPTION
Latest `weasyprint` version `61.2` is not compatible with `pydyf` version `0.11.0`.
It causes error during runtime while generating PDFs.

This fix freezes `pydyf` version to `0.10.0`.

Refs: OPMONDEV-187