### PR TITLE
fix: Migrate mongopy's collection#update to collection#update_one

### DIFF
--- a/anonymizer_module/opmon_anonymizer/iio/mongodbmanager.py
+++ b/anonymizer_module/opmon_anonymizer/iio/mongodbmanager.py
@@ -138,9 +138,9 @@ class MongoDbManager(BaseMongoDbManager):
         if not self.last_processed_timestamp:
             return
 
-        self.state_db.state.update(
+        self.state_db.state.update_one(
             {'key': 'last_mongodb_timestamp'},
-            {'key': 'last_mongodb_timestamp', 'value': str(self.last_processed_timestamp)},
+            {"$set": {'key': 'last_mongodb_timestamp', 'value': str(self.last_processed_timestamp)}},
             upsert=True
         )
 
@@ -219,8 +219,8 @@ class MongoDbOpenDataManager(BaseMongoDbManager):
         if not self.last_processed_timestamp:
             return
 
-        self.state_db.opendata_state.update(
+        self.state_db.opendata_state.update_one(
             {'key': 'last_mongodb_timestamp'},
-            {'key': 'last_mongodb_timestamp', 'value': str(self.last_processed_timestamp)},
+            {"$set": {'key': 'last_mongodb_timestamp', 'value': str(self.last_processed_timestamp)}},
             upsert=True
         )

--- a/corrector_module/opmon_corrector/database_manager.py
+++ b/corrector_module/opmon_corrector/database_manager.py
@@ -235,7 +235,7 @@ class DatabaseManager:
         try:
             db = self.get_query_db()
             clean_data = db[CLEAN_DATA_COLLECTION]
-            clean_data.replace_one({'_id': document['_id']}, document)
+            clean_data.update_one({'_id': document['_id']}, document)
         except Exception as e:
             self.logger_m.log_exception('DatabaseManager.update_form_clean_data', repr(e))
             raise e

--- a/corrector_module/opmon_corrector/database_manager.py
+++ b/corrector_module/opmon_corrector/database_manager.py
@@ -235,7 +235,7 @@ class DatabaseManager:
         try:
             db = self.get_query_db()
             clean_data = db[CLEAN_DATA_COLLECTION]
-            clean_data.update_one({'_id': document['_id']}, document)
+            clean_data.update_one({'_id': document['_id']}, {"$set": document})
         except Exception as e:
             self.logger_m.log_exception('DatabaseManager.update_form_clean_data', repr(e))
             raise e

--- a/reports_module/opmon_reports/database_manager.py
+++ b/reports_module/opmon_reports/database_manager.py
@@ -350,7 +350,7 @@ class DatabaseManager:
             db = self.mongodb_handler.get_reports_state_db()
             collection = db[NOTIFICATION_COLLECTION]
 
-            collection.update(
+            collection.update_one(
                 {
                     "_id": object_id
                 },
@@ -376,7 +376,7 @@ class DatabaseManager:
             db = self.mongodb_handler.get_reports_state_db()
             collection = db[NOTIFICATION_COLLECTION]
 
-            collection.update(
+            collection.update_one(
                 {
                     "_id": object_id
                 },


### PR DESCRIPTION
`mongopy` [migration guide](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-update-is-removed) states that the method `Collection.update` is removed and `Collection.update_one` (or `Collection.update_many`) should be used instead.

This PR fixes the code accordingly.

Refs: OPMONDEV-187