### PR TITLE
Dependabot/opendata upd to django4

### DIFF
--- a/analysis_ui_module/opmon_analyzer_ui/django_settings.py
+++ b/analysis_ui_module/opmon_analyzer_ui/django_settings.py
@@ -141,6 +141,7 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
+USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)

--- a/analysis_ui_module/opmon_analyzer_ui/django_settings.py
+++ b/analysis_ui_module/opmon_analyzer_ui/django_settings.py
@@ -141,7 +141,6 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)

--- a/opendata_module/opmon_opendata/django_settings.py
+++ b/opendata_module/opmon_opendata/django_settings.py
@@ -146,7 +146,6 @@ AUTH_PASSWORD_VALIDATORS = [
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)

--- a/opendata_module/opmon_opendata/tests/test_settings.py
+++ b/opendata_module/opmon_opendata/tests/test_settings.py
@@ -27,5 +27,4 @@ SECRET_KEY = 'test'
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True

--- a/opendata_module/setup.py
+++ b/opendata_module/setup.py
@@ -27,7 +27,7 @@ from setuptools import setup, find_packages
 requirements = [
     'setuptools==75.2.0',
     'dill==0.3.9',
-    'django==3.2.20',
+    'django==4.2.18',
     'pymongo==4.10.1',
     'pyyaml==6.0.2',
     'psycopg2==2.9.10',


### PR DESCRIPTION
update django dependency for opendata module to 4.2.18.

- USE_L10N removed due to deprecation: https://docs.djangoproject.com/en/5.1/releases/4.0/#localization