### PR TITLE
chore: ignore dependencies by dependabot; bump some dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,15 @@ updates:
       - dependency-name: "rpds-py"
         versions:
           - ">= 0.21.0"
+      - dependency-name: "vcrpy"
+        versions:
+          - ">= 7.0.0"
+      - dependency-name: "setuptools"
+        versions:
+          - ">= 75.4.0"
+      - dependency-name: "urllib3"
+        versions:
+          - ">= 2.3.0"
 
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"

--- a/anonymizer_module/setup.py
+++ b/anonymizer_module/setup.py
@@ -25,7 +25,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'setuptools==75.2.0',
+    'setuptools==75.3.0',
     'pymongo==4.10.1',
     'pyyaml==6.0.2',
     'psycopg2==2.9.10',

--- a/collector_module/setup.py
+++ b/collector_module/setup.py
@@ -25,10 +25,10 @@
 from setuptools import setup
 
 requirements = [
-    'setuptools==75.2.0',
+    'setuptools==75.3.0',
     'pymongo==4.10.1',
     'requests==2.32.3',
-    'tqdm==4.66.5',
+    'tqdm==4.67.1',
     'pyyaml==6.0.2',
     'urllib3==2.2.3',
 ]

--- a/corrector_module/setup.py
+++ b/corrector_module/setup.py
@@ -25,7 +25,7 @@
 from setuptools import setup
 
 requirements = [
-    'setuptools==75.2.0',
+    'setuptools==75.3.0',
     'pymongo==4.10.1',
     'pyyaml==6.0.2',
 ]

--- a/opendata_module/setup.py
+++ b/opendata_module/setup.py
@@ -25,7 +25,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'setuptools==75.2.0',
+    'setuptools==75.3.0',
     'dill==0.3.9',
     'django==4.2.18',
     'pymongo==4.10.1',

--- a/reports_module/setup.py
+++ b/reports_module/setup.py
@@ -29,8 +29,8 @@ from setuptools import setup, find_packages
 
 requirements = [
     'markupsafe==2.1.5',
-    'Jinja2==3.1.4',
-    'matplotlib==3.1.2',
+    'Jinja2==3.1.5',
+    'matplotlib==3.7.5',
     'pandas==2.0.3',
     'weasyprint==61.2',
     'Pillow==10.4.0',


### PR DESCRIPTION
Added `ignore` sections for dependabot for dependencies:
- vcrpy>= 7.0.0
- setuptools">= 75.4.0
- urllib3 >= 2.3.0
because Python >=3.9 is required for those.

Bumped other dependency versions according to https://github.com/nordic-institute/X-Road-Metrics/pull/162.

Related dependabot PRs:
https://github.com/nordic-institute/X-Road-Metrics/pull/163 - rejected that one
https://github.com/nordic-institute/X-Road-Metrics/pull/162 - will reject that one as well