### PR TITLE
fix: exclude backslashes from initially generated passwords

### DIFF
--- a/collector_module/opmon_mongodb_maintenance/create_users.py
+++ b/collector_module/opmon_mongodb_maintenance/create_users.py
@@ -109,16 +109,26 @@ def _print_users(passwords: dict):
     [print(f'{user:<{width}}| {password} | {_escape_password(password)}') for user, password in passwords.items()]
 
 
+def _get_password_character_set():
+    """
+    Generate a set of characters from which to compose a password.
+    Some characters are avoided because they cause issues in a .yaml file, even after being escaped.
+    """
+    avoid_chars = "\\"
+    allowed_character_set = "".join(
+        c for c in (string.ascii_letters + string.digits + string.punctuation)
+        if c not in avoid_chars
+    )
+    return allowed_character_set
+
 def _generate_password():
     """
     Generate a random 12 character password.
 
     Password contains lower-case, upper-case, numbers and special characters.
     Based on best-practice recipe from https://docs.python.org/3/library/secrets.html.
-    Some characters are avoided because they cause issues in a .yaml file, even after being escaped.
     """
-    avoid_chars = "\\"
-    alphabet = "".join(c for c in (string.ascii_letters + string.digits + string.punctuation) if c not in avoid_chars)
+    alphabet = _get_password_character_set()
     while True:
         password = ''.join(secrets.choice(alphabet) for _ in range(12))
         if (any(c.islower() for c in password)

--- a/collector_module/opmon_mongodb_maintenance/create_users.py
+++ b/collector_module/opmon_mongodb_maintenance/create_users.py
@@ -115,8 +115,10 @@ def _generate_password():
 
     Password contains lower-case, upper-case, numbers and special characters.
     Based on best-practice recipe from https://docs.python.org/3/library/secrets.html.
+    Some characters are avoided because they cause issues in a .yaml file, even after being escaped.
     """
-    alphabet = string.ascii_letters + string.digits + string.punctuation
+    avoid_chars = "\\"
+    alphabet = "".join(c for c in (string.ascii_letters + string.digits + string.punctuation) if c not in avoid_chars)
     while True:
         password = ''.join(secrets.choice(alphabet) for _ in range(12))
         if (any(c.islower() for c in password)

--- a/collector_module/opmon_mongodb_maintenance/tests/test_create_users.py
+++ b/collector_module/opmon_mongodb_maintenance/tests/test_create_users.py
@@ -134,11 +134,10 @@ def test_opmon_user_generation_without_passwords(mocker):
         assert to_find in passwords.keys()
 
 
-def test_generated_password_has_no_backslashes():
+def test_password_character_set():
     backslash_char = "\\"
-    for _ in range(1000):
-        password = create_users._generate_password()
-        assert backslash_char not in password
+    allowed_chars = create_users._get_password_character_set()
+    assert backslash_char not in allowed_chars
 
 def test_password_escaping():
     password = """:/foo'"\\_*{}[]''"""

--- a/collector_module/opmon_mongodb_maintenance/tests/test_create_users.py
+++ b/collector_module/opmon_mongodb_maintenance/tests/test_create_users.py
@@ -134,6 +134,12 @@ def test_opmon_user_generation_without_passwords(mocker):
         assert to_find in passwords.keys()
 
 
+def test_generated_password_has_no_backslashes():
+    backslash_char = "\\"
+    for _ in range(1000):
+        password = create_users._generate_password()
+        assert backslash_char not in password
+
 def test_password_escaping():
     password = """:/foo'"\\_*{}[]''"""
     escaped_password = create_users._escape_password(password)

--- a/opendata_module/opmon_postgresql_maintenance/create_users.py
+++ b/opendata_module/opmon_postgresql_maintenance/create_users.py
@@ -244,16 +244,26 @@ def _print_users(passwords: Dict[str, str]) -> None:
     [print(f'{user:<{width}}| {password} | {_escape_password(password)}') for user, password in passwords.items()]
 
 
-def _generate_password() -> str:
+def _get_password_character_set():
+    """
+    Generate a set of characters from which to compose a password.
+    Some characters are avoided because they cause issues in a .yaml file, even after being escaped.
+    """
+    avoid_chars = "\\"
+    allowed_character_set = "".join(
+        c for c in (string.ascii_letters + string.digits + string.punctuation)
+        if c not in avoid_chars
+    )
+    return allowed_character_set
+
+def _generate_password():
     """
     Generate a random 12 character password.
 
     Password contains lower-case, upper-case, numbers and special characters.
     Based on best-practice recipe from https://docs.python.org/3/library/secrets.html.
-    Some characters are avoided because they cause issues in a .yaml file, even after being escaped.
     """
-    avoid_chars = "\\"
-    alphabet = "".join(c for c in (string.ascii_letters + string.digits + string.punctuation) if c not in avoid_chars)
+    alphabet = _get_password_character_set()
     while True:
         password = ''.join(secrets.choice(alphabet) for i in range(12))
         if (any(c.islower() for c in password)

--- a/opendata_module/opmon_postgresql_maintenance/create_users.py
+++ b/opendata_module/opmon_postgresql_maintenance/create_users.py
@@ -250,8 +250,10 @@ def _generate_password() -> str:
 
     Password contains lower-case, upper-case, numbers and special characters.
     Based on best-practice recipe from https://docs.python.org/3/library/secrets.html.
+    Some characters are avoided because they cause issues in a .yaml file, even after being escaped.
     """
-    alphabet = string.ascii_letters + string.digits + string.punctuation
+    avoid_chars = "\\"
+    alphabet = "".join(c for c in (string.ascii_letters + string.digits + string.punctuation) if c not in avoid_chars)
     while True:
         password = ''.join(secrets.choice(alphabet) for i in range(12))
         if (any(c.islower() for c in password)

--- a/opendata_module/opmon_postgresql_maintenance/tests/test_create_users.py
+++ b/opendata_module/opmon_postgresql_maintenance/tests/test_create_users.py
@@ -160,6 +160,11 @@ def test_grant_priviledges(mocker):
     for call_args_list in cursor.execute.call_args_list:
         assert call_args_list.args[0].startswith('GRANT')
 
+def test_generated_password_has_no_backslashes():
+    backslash_char = "\\"
+    for _ in range(1000):
+        password = create_users._generate_password()
+        assert backslash_char not in password
 
 def test_password_escaping():
     password = """:/foo'"\\_*{}[]''"""

--- a/opendata_module/opmon_postgresql_maintenance/tests/test_create_users.py
+++ b/opendata_module/opmon_postgresql_maintenance/tests/test_create_users.py
@@ -160,11 +160,10 @@ def test_grant_priviledges(mocker):
     for call_args_list in cursor.execute.call_args_list:
         assert call_args_list.args[0].startswith('GRANT')
 
-def test_generated_password_has_no_backslashes():
+def test_password_character_set():
     backslash_char = "\\"
-    for _ in range(1000):
-        password = create_users._generate_password()
-        assert backslash_char not in password
+    allowed_chars = create_users._get_password_character_set()
+    assert backslash_char not in allowed_chars
 
 def test_password_escaping():
     password = """:/foo'"\\_*{}[]''"""


### PR DESCRIPTION
Refs: OPMONDEV-192