### PR TITLE
docs: Add more info regarding postgres 15+ usage during automatic user creation

### DIFF
--- a/docs/opendata_module.md
+++ b/docs/opendata_module.md
@@ -133,8 +133,13 @@ sudo apt install postgresql
 > For automatic users creation to work properly, PostgreSQL version must be 14 or less.  
 > Starting from PostgreSQL 15, ownership of `public` schema has changed to the new `pg_database_owner` role. 
 > Due to this change, the command will create users but without proper permissions to create tables in the database's
-> public schema. In this case, make sure to grant proper permissions to user `anonymizer_ex` manually.  
-> For more information, see [PostgreSQL 15 Release Notes - Migration](https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.18.4). 
+> public schema. In this case, after creating users with the below script, connect to the database, and grant `create`
+> and `usage` permissions on `public` schema to user `anonymizer_ex` using the following SQL statement:
+> ```sql
+> GRANT CREATE, USAGE ON SCHEMA public TO anonymizer_ex;
+> ```
+> 
+> For more information, see [PostgreSQL 15 Release Notes - Migration](https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.18.4).
 
 The X-Road Metrics Opendata package includes a command that creates the PostgreSQL users automatically.
 To create PostgreSQL users for X-Road instance *LTT* on `localhost` run the following commands:

--- a/docs/opendata_module.md
+++ b/docs/opendata_module.md
@@ -128,12 +128,26 @@ sudo apt install postgresql
 ```
 
 ### Automatic PostgreSQL User Creation
+
+> [!IMPORTANT]
+> For automatic users creation to work properly, PostgreSQL version must be 14 or less.  
+> Starting from PostgreSQL 15, ownership of `public` schema has changed to the new `pg_database_owner` role. 
+> Due to this change, the command will create users but without proper permissions to create tables in the database's
+> public schema. In this case, make sure to grant proper permissions to user `anonymizer_ex` manually.  
+> For more information, see [PostgreSQL 15 Release Notes - Migration](https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.18.4). 
+
 The X-Road Metrics Opendata package includes a command that creates the PostgreSQL users automatically.
-To create PostgreSQL users for X-Road instance *LTT* run the following commands:
+To create PostgreSQL users for X-Road instance *LTT* on `localhost` run the following commands:
 
 ```bash
 sudo su postgres
 xroad-metrics-init-postgresql LTT
+```
+
+**Note:** For remote database connection, the `--host`, `--user` and `--password` parameters are required, where 
+`host` value must contain both hostname and port separated by a colon. For example:
+```bash
+xroad-metrics-init-postgresql --host remoteserver:5432 --user postgres --password postgres LTT
 ```
 
 The command output includes a list of usernames and passwords generated:


### PR DESCRIPTION
Starting from PostgreSQL 15, ownership of `public` schema has changed to the new `pg_database_owner` role.   
Due to this change, the `xroad-metrics-init-postgresql` will create users but without proper permissions to create tables in the database's public schema. 

This PR updates the relative section in the docs with this information.  

More details can be found in the [PostgreSQL 15 Release Notes - Migration](https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.18.4) and this [StackOverflow thread](https://stackoverflow.com/questions/78612958/user-cannot-create-table-on-schema-public-postgres-16)