### PR TITLE
Optimize Dockerfiles with multi-stage builds and metrics-base stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,93 @@
+# =============================================================================
+# .dockerignore - Exclude files from Docker build context
+# =============================================================================
+
+# Git
+.git
+.gitignore
+.github
+
+# IDE and editor settings
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Python bytecode and cache
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
+**/.mypy_cache/
+**/.ruff_cache/
+**/.pytest_cache/
+.cache
+
+# Virtual environments
+venv/
+env/
+.venv/
+.Python
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+*.deb
+*.dsc
+*.tar.xz
+*.buildinfo
+*.changes
+sdist/
+wheels/
+
+# Test and coverage
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+coverage.xml
+nosetests.xml
+test_results.*
+.hypothesis/
+**/tests/
+integration_tests/
+
+# Documentation (not needed in containers)
+docs/
+*.md
+!README.md
+
+# Logs
+*.log
+logs/
+
+# Database files
+*.sqlite3
+
+# MacOS
+.DS_Store
+
+# Claude/AI assistant
+.claude/
+
+# Development files
+.devcontainer/
+.scannerwork/
+.ort.yml
+ruff.toml
+
+# Debian packaging files (not needed for Docker)
+Dockerfile_focal
+Dockerfile_jammy
+
+# Archive module (not containerized)
+archive_module/
+
+# Unreleased modules
+unreleased_modules/
+
+# Artifacts directory
+artifacts/

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -7,6 +7,7 @@
 - [Building All Containers](#building-all-containers)
 - [Overriding `settings.yaml` Values](#overriding-settingsyaml-values)
 - [Overriding Settings with Environment Variables (Entrypoint Script)](#overriding-settings-with-environment-variables-entrypoint-script)
+- [Container Logging](#container-logging)
 - [Running the environment](#running-the-environment)
 - [Cleanup](#cleanup)
 
@@ -117,6 +118,20 @@ modifying the file directly. Note that this will also do substitutions in your `
 
 For more details on the supported environment variable format and substitution logic, see the comments in
 `Docker/docker-entrypoint.sh` and the main project documentation.
+
+## Container Logging
+
+By default, the [entrypoint script](./docker-entrypoint.sh) redirects module log files to stdout by creating symlinks. This allows viewing logs
+via `docker logs` or `docker compose logs` instead of accessing files inside the container.
+
+The following logs are redirected:
+
+- Main module log: `log_<logger-name>_<instance>.json`
+- Networking module's data preparation log: `prepare_data_log.json`
+
+> [!NOTE]
+> In case of Networking module, Shiny server will produce a warning about log file is created as a symlink. 
+> This warning can be ignored.
 
 ## Running the environment
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -102,18 +102,21 @@ For more details on the supported environment variable format and substitution l
 
 ## Running the environment
 
-The containers can be run with `docker compose up -d` in the `Docker` directory. After this you can run specific commands such
-as collecting by running it on the container, for example:
+The containers can be run with the following command from the `Docker` directory:
 
 ```bash
-docker compose run --rm collector_module collect
+docker compose up -d
 ```
 
-**Note:** When you run the Collector for the very first time, first you must run `update` and then `collect`:
+After this you can run specific commands by running it on the container (other containers are up and running in the background):
 
 ```bash
 docker compose run --rm collector_module update
 docker compose run --rm collector_module collect
+docker compose run --rm anonymizer_module
+docker compose run --rm opendata_collector_module
+# generate reports for data up to today
+docker compose run --rm reports_module --end-date $(date +%Y-%m-%d) report
 ```
 
 There is a web based UI for both the MongoDB and PostgreSQL databases on ports `8081` and `8082` respectively. For passwords,
@@ -127,6 +130,12 @@ e.g., `http://localhost:8000/static/gui/index_en.html`.
 - For more details on module-specific configuration, see the documentation in `docs/` and the main project `README.md`.
 
 ## Cleanup
+
+To remove all X-Road Metrics containers, volumes, and networks created by Docker Compose:
+
+```bash
+docker compose down -v
+```
 
 To remove all X-Road Metrics images:
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -24,7 +24,7 @@ has been set up and configured with the monitoring client (note that the subsyst
 
 The subsystem should have `HTTP` selected as the connection method.
 
-## Harware requirements
+## Hardware requirements
 
 This Docker setup is only intended for limited local testing. Most modules run only when explicitly ran. Only the following containers run
 continuously, with the `corrector` running in batches:
@@ -41,11 +41,13 @@ usage you will see. The setup itself can be ran with **1GB** of memory, potentia
 
 ## Building All Containers
 
-To build all module containers, run the following script from the project root:
+To build all module containers, run the build script from the project root:
 
 ```bash
 bash Docker/prepare-containers.sh
 ```
+
+The script can also be run from any directory using an absolute path.
 
 This will build Docker images for:
 - xroad-metrics-collector-module
@@ -54,11 +56,13 @@ This will build Docker images for:
 - xroad-metrics-opendata-module
 - xroad-metrics-opendata-collector-module
 - xroad-metrics-reports-module
+- xroad-metrics-networking-module
 
-To build just one module, you can run the command with:
+To build specific modules, you can specify one or more module names:
 
 ```bash
-bash Docker/prepare-containers.sh [module_name]
+bash Docker/prepare-containers.sh collector_module
+bash Docker/prepare-containers.sh collector_module corrector_module
 ```
 
 ## Overriding `settings.yaml` Values
@@ -121,3 +125,11 @@ e.g., `http://localhost:8000/static/gui/index_en.html`.
 ## Notes
 - The `prepare-containers.sh` script will build all modules in sequence.
 - For more details on module-specific configuration, see the documentation in `docs/` and the main project `README.md`.
+
+## Cleanup
+
+To remove all X-Road Metrics images:
+
+```bash
+docker image rm $(docker images 'xroad-metrics-*' -q)
+```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,4 +1,16 @@
-# X-Road Metrics Docker Containers
+# X-Road Metrics Docker Containers <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [Introduction](#introduction)
+- [Hardware requirements](#hardware-requirements)
+- [Building All Containers](#building-all-containers)
+- [Overriding `settings.yaml` Values](#overriding-settingsyaml-values)
+- [Overriding Settings with Environment Variables (Entrypoint Script)](#overriding-settings-with-environment-variables-entrypoint-script)
+- [Running the environment](#running-the-environment)
+- [Cleanup](#cleanup)
+
+## Introduction
 
 This directory contains Dockerfiles and scripts for building the containers for each module in the X-Road Metrics project. And
 running them with Docker Compose.
@@ -50,6 +62,7 @@ bash Docker/prepare-containers.sh
 The script can also be run from any directory using an absolute path.
 
 This will build Docker images for:
+
 - xroad-metrics-collector-module
 - xroad-metrics-corrector-module
 - xroad-metrics-anonymizer-module
@@ -64,6 +77,11 @@ To build specific modules, you can specify one or more module names:
 bash Docker/prepare-containers.sh collector_module
 bash Docker/prepare-containers.sh collector_module corrector_module
 ```
+
+> [!NOTE]
+>
+> - The `prepare-containers.sh` script will build all modules in sequence.
+> - For more details on module-specific configuration, see the documentation in `docs/` and the main project `README.md`.
 
 ## Overriding `settings.yaml` Values
 
@@ -102,32 +120,74 @@ For more details on the supported environment variable format and substitution l
 
 ## Running the environment
 
-The containers can be run with the following command from the `Docker` directory:
+From the `Docker` directory, follow these steps:
+
+- **Databases**
 
 ```bash
-docker compose up -d
+docker compose up -d mongodb postgresql
 ```
 
-After this you can run specific commands by running it on the container (other containers are up and running in the background):
+- **_(Optional)_ Run web UIs for databases**
+
+```bash
+docker compose up -d mongo-express adminer
+```
+
+UIs are accessible via http://localhost:8081 and http://localhost:8082 respectively.
+For passwords, review the [docker-compose.yaml](./docker-compose.yaml) file.
+
+- **Collector**
 
 ```bash
 docker compose run --rm collector_module update
+```
+
+and then 
+
+```bash
 docker compose run --rm collector_module collect
-docker compose run --rm anonymizer_module
-docker compose run --rm opendata_collector_module
-# generate reports for data up to today
+```
+
+- **Corrector**
+
+```bash
+docker compose up -d corrector_module
+```
+
+- **Reports** for data up to today's date:
+
+```bash
 docker compose run --rm reports_module --end-date $(date +%Y-%m-%d) report
 ```
 
-There is a web based UI for both the MongoDB and PostgreSQL databases on ports `8081` and `8082` respectively. For passwords,
-review the `docker-compose.yaml` file.
+- **Anonymizer**
 
-Instead, the Opendata module UI is accessible on port `8000` under the path `/static/gui/index_en.html`,
-e.g., `http://localhost:8000/static/gui/index_en.html`.
+```bash
+docker compose run --rm anonymizer_module
+```
 
-## Notes
-- The `prepare-containers.sh` script will build all modules in sequence.
-- For more details on module-specific configuration, see the documentation in `docs/` and the main project `README.md`.
+- **Opendata**
+
+```bash
+docker compose up -d opendata_module
+```
+
+UI is accessible on port `8000` via http://localhost:8000.
+
+- **Networking**
+
+```bash
+docker compose up -d networking_module
+```
+
+UI is accessible on port `8001` via http://localhost:8001.
+
+- **Opendata Collector**, if needed:
+
+```bash
+docker compose run --rm opendata_collector_module
+```
 
 ## Cleanup
 

--- a/Docker/anonymizer_module/Dockerfile
+++ b/Docker/anonymizer_module/Dockerfile
@@ -1,7 +1,9 @@
+ARG BASE_IMAGE=set-via-prepare-containers.sh
+
 # =============================================================================
 # Builder Stage - Compile Python dependencies
 # =============================================================================
-FROM python:3.8-slim AS builder
+FROM ${BASE_IMAGE} AS builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -14,31 +16,9 @@ COPY anonymizer_module/ ./
 RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
 
 # =============================================================================
-# Base Stage - Common setup for all X-Road Metrics modules
+# Anonymizer Module
 # =============================================================================
-FROM python:3.8-slim AS metrics-base
-
-ARG YQ_VERSION=4.43.1
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq \
-    && apt-get purge -y wget \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN adduser --system --group --no-create-home xroad-metrics
-
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-WORKDIR /app
-
-# =============================================================================
-# Runtime Stage
-# =============================================================================
-FROM metrics-base AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 # Install runtime library for PostgreSQL
 RUN apt-get update \

--- a/Docker/anonymizer_module/Dockerfile
+++ b/Docker/anonymizer_module/Dockerfile
@@ -1,29 +1,72 @@
-FROM python:3.8-slim
-
-WORKDIR /app
+# =============================================================================
+# Builder Stage - Compile Python dependencies
+# =============================================================================
+FROM python:3.8-slim AS builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \
-        wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY anonymizer_module/ ./
+RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
+
+# =============================================================================
+# Base Stage - Common setup for all X-Road Metrics modules
+# =============================================================================
+FROM python:3.8-slim AS metrics-base
+
+ARG YQ_VERSION=4.43.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
     && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY anonymizer_module/ ./
-
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
+RUN adduser --system --group --no-create-home xroad-metrics
 
 COPY Docker/docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /app
+
+# =============================================================================
+# Runtime Stage
+# =============================================================================
+FROM metrics-base AS runtime
+
+# Install runtime library for PostgreSQL
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir /wheels/* \
+    && rm -rf /wheels \
+    && pip uninstall -y pip setuptools wheel \
+    && rm -rf /usr/local/lib/python*/site-packages/pip* \
+              /usr/local/lib/python*/site-packages/setuptools* \
+              /usr/local/lib/python*/site-packages/wheel* \
+    && find /usr/local/lib/python*/site-packages -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true \
+    && find /usr/local/lib/python*/site-packages -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
+
+COPY anonymizer_module/ ./
 
 RUN mkdir -p /var/log/xroad-metrics/anonymizer/logs /var/run/xroad-metrics \
     && mkdir -p /etc/xroad-metrics/anonymizer \
     && cp /app/etc/field_data.yaml /etc/xroad-metrics/anonymizer/ \
     && cp /app/etc/field_translations.list /etc/xroad-metrics/anonymizer/ \
     && ln -s /app/etc/settings.yaml /app/settings.yaml \
-    && chmod +x /app/bin/xroad-metrics-anonymizer /entrypoint.sh
+    && chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics /var/run/xroad-metrics \
+       /etc/xroad-metrics/anonymizer /app \
+    && chmod +x /app/bin/xroad-metrics-anonymizer
+
+USER xroad-metrics
 
 ENTRYPOINT ["/entrypoint.sh", "/app/bin/xroad-metrics-anonymizer"]

--- a/Docker/collector_module/Dockerfile
+++ b/Docker/collector_module/Dockerfile
@@ -1,13 +1,44 @@
-FROM python:3.8-slim
-WORKDIR /app
-COPY collector_module /app
-COPY collector_module/etc/* /app/
-RUN pip install --upgrade pip \
-    && pip install -r requirements.txt
-RUN apt-get update && apt-get install -y wget && \
-    wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 && \
-    chmod +x /usr/bin/yq
-RUN mkdir -p /var/log/xroad-metrics/collector/logs
+# =============================================================================
+# Base Stage - Common setup for all X-Road Metrics modules
+# =============================================================================
+FROM python:3.8-slim AS metrics-base
+
+ARG YQ_VERSION=4.43.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --system --group --no-create-home xroad-metrics
+
 COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /app/bin/xroad-metrics-collector
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /app
+
+# =============================================================================
+# Runtime Stage
+# =============================================================================
+FROM metrics-base AS runtime
+
+COPY collector_module/ ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip uninstall -y pip setuptools wheel \
+    && rm -rf /usr/local/lib/python*/site-packages/pip* \
+              /usr/local/lib/python*/site-packages/setuptools* \
+              /usr/local/lib/python*/site-packages/wheel* \
+    && find /usr/local/lib/python*/site-packages -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true \
+    && find /usr/local/lib/python*/site-packages -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
+
+RUN mkdir -p /var/log/xroad-metrics/collector/logs /var/run/xroad-metrics \
+    && ln -s /app/etc/settings.yaml /app/settings.yaml \
+    && chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics /var/run/xroad-metrics /app \
+    && chmod +x /app/bin/xroad-metrics-collector
+
+USER xroad-metrics
+
 ENTRYPOINT ["/entrypoint.sh", "/app/bin/xroad-metrics-collector"]

--- a/Docker/collector_module/Dockerfile
+++ b/Docker/collector_module/Dockerfile
@@ -1,29 +1,9 @@
-# =============================================================================
-# Base Stage - Common setup for all X-Road Metrics modules
-# =============================================================================
-FROM python:3.8-slim AS metrics-base
-
-ARG YQ_VERSION=4.43.1
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq \
-    && apt-get purge -y wget \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN adduser --system --group --no-create-home xroad-metrics
-
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-WORKDIR /app
+ARG BASE_IMAGE=set-via-prepare-containers.sh
 
 # =============================================================================
-# Runtime Stage
+# Collector Module
 # =============================================================================
-FROM metrics-base AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 COPY collector_module/ ./
 RUN pip install --no-cache-dir -r requirements.txt \

--- a/Docker/corrector_module/Dockerfile
+++ b/Docker/corrector_module/Dockerfile
@@ -1,29 +1,9 @@
-# =============================================================================
-# Base Stage - Common setup for all X-Road Metrics modules
-# =============================================================================
-FROM python:3.8-slim AS metrics-base
-
-ARG YQ_VERSION=4.43.1
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq \
-    && apt-get purge -y wget \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN adduser --system --group --no-create-home xroad-metrics
-
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-WORKDIR /app
+ARG BASE_IMAGE=set-via-prepare-containers.sh
 
 # =============================================================================
-# Runtime Stage
+# Corrector Module
 # =============================================================================
-FROM metrics-base AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 COPY corrector_module/ ./
 RUN pip install --no-cache-dir -r requirements.txt \

--- a/Docker/corrector_module/Dockerfile
+++ b/Docker/corrector_module/Dockerfile
@@ -1,13 +1,44 @@
-FROM python:3.8-slim
-WORKDIR /app
-COPY corrector_module /app
-COPY corrector_module/etc/* /app/
-RUN pip install --upgrade pip \
-    && pip install -r requirements.txt
-RUN apt-get update && apt-get install -y wget && \
-    wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 && \
-    chmod +x /usr/bin/yq
-RUN mkdir -p /var/log/xroad-metrics/corrector/logs
+# =============================================================================
+# Base Stage - Common setup for all X-Road Metrics modules
+# =============================================================================
+FROM python:3.8-slim AS metrics-base
+
+ARG YQ_VERSION=4.43.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --system --group --no-create-home xroad-metrics
+
 COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /app/bin/xroad-metrics-correctord
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /app
+
+# =============================================================================
+# Runtime Stage
+# =============================================================================
+FROM metrics-base AS runtime
+
+COPY corrector_module/ ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip uninstall -y pip setuptools wheel \
+    && rm -rf /usr/local/lib/python*/site-packages/pip* \
+              /usr/local/lib/python*/site-packages/setuptools* \
+              /usr/local/lib/python*/site-packages/wheel* \
+    && find /usr/local/lib/python*/site-packages -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true \
+    && find /usr/local/lib/python*/site-packages -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
+
+RUN mkdir -p /var/log/xroad-metrics/corrector/logs /var/run/xroad-metrics \
+    && ln -s /app/etc/settings.yaml /app/settings.yaml \
+    && chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics /var/run/xroad-metrics /app \
+    && chmod +x /app/bin/xroad-metrics-correctord
+
+USER xroad-metrics
+
 ENTRYPOINT ["/entrypoint.sh", "/app/bin/xroad-metrics-correctord"]

--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -29,6 +29,8 @@ services:
       - setting_mongodb.user=correctordev
       - setting_mongodb.password=correctordevpw
       - setting_mongodb.host=mongodb
+      - setting_corrector.wait-on-done=60
+      - setting_corrector.wait-on-error=60
     networks:
       - xrd-metrics-network
     depends_on:

--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -204,6 +204,8 @@ services:
     depends_on:
       postgresql:
         condition: service_healthy
+      anonymizer_module:
+        condition: service_started
 
 networks:
   xrd-metrics-network:

--- a/Docker/docker-entrypoint.sh
+++ b/Docker/docker-entrypoint.sh
@@ -40,6 +40,8 @@ if [ -f "$METRICS_SETTINGS_FILE" ]; then
     if [ -n "$LOG_PATH" ] && [ -n "$INSTANCE" ] && [ -n "$LOGGER_NAME" ]; then
       LOG_FILE="${LOG_PATH}/log_${LOGGER_NAME}_${INSTANCE}.json"
       ln -sf /dev/stdout "$LOG_FILE" 2>/dev/null || true
+      # Also redirect networking module's prepare_data log if log path exists
+      ln -sf /dev/stdout "${LOG_PATH}/prepare_data_log.json" 2>/dev/null || true
     fi
   fi
 fi

--- a/Docker/metrics-base/Dockerfile
+++ b/Docker/metrics-base/Dockerfile
@@ -7,11 +7,12 @@ ARG PYTHON_VERSION=3.8-slim
 
 FROM python:${PYTHON_VERSION}
 
-ARG YQ_VERSION=4.43.1
+ARG YQ_VERSION=4.50.1
 
 # Install yq for YAML configuration manipulation
 RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && ARCH=$(dpkg --print-architecture) \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${ARCH} \
     && chmod +x /usr/bin/yq \
     && apt-get purge -y wget \
     && apt-get autoremove -y \

--- a/Docker/metrics-base/Dockerfile
+++ b/Docker/metrics-base/Dockerfile
@@ -1,0 +1,28 @@
+# =============================================================================
+# X-Road Metrics Base Image
+# Common foundation for all Python-based X-Road Metrics modules
+# =============================================================================
+
+ARG PYTHON_VERSION=3.8-slim
+
+FROM python:${PYTHON_VERSION}
+
+ARG YQ_VERSION=4.43.1
+
+# Install yq for YAML configuration manipulation
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user for running modules
+RUN adduser --system --group --no-create-home xroad-metrics
+
+# Copy shared entrypoint script
+COPY Docker/docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /app

--- a/Docker/networking_module/Dockerfile
+++ b/Docker/networking_module/Dockerfile
@@ -1,6 +1,8 @@
-FROM rocker/shiny:4.3.2
+FROM rocker/shiny:4.5.2
 
-# Install system dependencies for ODBC, PostgreSQL, and GLPK (for igraph)
+ARG YQ_VERSION=4.43.1
+
+# Install system dependencies, yq, and cleanup
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         unixodbc \
@@ -9,12 +11,12 @@ RUN apt-get update \
         libglpk40 \
         cron \
         wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Install yq for settings processing
-RUN wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq
 
 # Install R packages needed by networking module
 RUN install2.r --error \
@@ -27,50 +29,43 @@ RUN install2.r --error \
     yaml \
     RODBC
 
-# Create xroad-metrics user (matching Debian package)
+# Create xroad-metrics user
 RUN groupadd -r xroad-metrics && useradd -r -g xroad-metrics xroad-metrics
 
-# Create directories (matching Debian package structure)
+# Create all directories
 RUN mkdir -p /var/log/xroad-metrics/networking/logs \
-    && mkdir -p /var/log/xroad-metrics/networking/heartbeat \
-    && mkdir -p /var/lib/xroad-metrics/networking \
-    && mkdir -p /etc/xroad-metrics/networking \
-    && mkdir -p /usr/share/xroad-metrics/networking/shiny/www \
-    && mkdir -p /var/log/shiny-server
+             /var/log/xroad-metrics/networking/heartbeat \
+             /var/lib/xroad-metrics/networking \
+             /etc/xroad-metrics/networking \
+             /usr/share/xroad-metrics/networking/shiny/www \
+             /var/log/shiny-server
 
-# Copy R scripts for data preparation (matching Debian package paths)
+# Copy all networking module files
 COPY networking_module/prepare_data.R /usr/share/xroad-metrics/networking/
 COPY networking_module/prepare_data_settings.R /usr/share/xroad-metrics/networking/
 COPY networking_module/networking-cron-entrypoint.sh /usr/share/xroad-metrics/networking/
-RUN chmod +x /usr/share/xroad-metrics/networking/prepare_data.R \
-    && chmod +x /usr/share/xroad-metrics/networking/networking-cron-entrypoint.sh
-
-# Create symlink matching Debian package
-RUN ln -s /usr/share/xroad-metrics/networking/prepare_data.R /usr/bin/xroad-metrics-networking
-
-# Copy Shiny app (matching Debian package paths)
 COPY networking_module/app.R /usr/share/xroad-metrics/networking/shiny/
 COPY networking_module/www/ /usr/share/xroad-metrics/networking/shiny/www/
-
-# Copy config files from etc/ (matching Debian package)
 COPY networking_module/etc/settings.yaml /etc/xroad-metrics/networking/
 COPY networking_module/etc/shiny-server/shiny-server.conf /etc/shiny-server/
 COPY networking_module/etc/cron.d/xroad-metrics-networking-cron /etc/cron.d/
-RUN chmod 0644 /etc/cron.d/xroad-metrics-networking-cron
+COPY Docker/docker-entrypoint.sh /entrypoint.sh
+COPY Docker/networking_module/startup.sh /startup.sh
+
+# Set permissions and create symlink
+RUN chmod +x /usr/share/xroad-metrics/networking/prepare_data.R \
+             /usr/share/xroad-metrics/networking/networking-cron-entrypoint.sh \
+             /entrypoint.sh \
+             /startup.sh \
+    && chmod 0644 /etc/cron.d/xroad-metrics-networking-cron \
+    && ln -s /usr/share/xroad-metrics/networking/prepare_data.R /usr/bin/xroad-metrics-networking \
+    && chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics/networking \
+                                            /var/lib/xroad-metrics/networking \
+                                            /usr/share/xroad-metrics/networking \
+                                            /var/log/shiny-server
 
 # Set environment variable for entrypoint to find settings
 ENV METRICS_SETTINGS_FILE=/etc/xroad-metrics/networking/settings.yaml
-
-# Copy entrypoint and startup scripts
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-COPY Docker/networking_module/startup.sh /startup.sh
-RUN chmod +x /entrypoint.sh /startup.sh
-
-# Set permissions
-RUN chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics/networking \
-    && chown -R xroad-metrics:xroad-metrics /var/lib/xroad-metrics/networking \
-    && chown -R xroad-metrics:xroad-metrics /usr/share/xroad-metrics/networking \
-    && chown -R xroad-metrics:xroad-metrics /var/log/shiny-server
 
 EXPOSE 3838
 CMD ["/startup.sh"]

--- a/Docker/networking_module/Dockerfile
+++ b/Docker/networking_module/Dockerfile
@@ -1,6 +1,6 @@
 FROM rocker/shiny:4.5.2
 
-ARG YQ_VERSION=4.43.1
+ARG YQ_VERSION=4.50.1
 
 # Install system dependencies, yq, and cleanup
 RUN apt-get update \
@@ -11,7 +11,8 @@ RUN apt-get update \
         libglpk40 \
         cron \
         wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && ARCH=$(dpkg --print-architecture) \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${ARCH} \
     && chmod +x /usr/bin/yq \
     && apt-get purge -y wget \
     && apt-get autoremove -y \

--- a/Docker/opendata_collector_module/Dockerfile
+++ b/Docker/opendata_collector_module/Dockerfile
@@ -1,13 +1,44 @@
-FROM python:3.8-slim
-WORKDIR /app
-COPY opendata_collector_module /app
-COPY opendata_collector_module/etc/* /app/
-RUN pip install --upgrade pip \
-    && pip install -r requirements.txt
-RUN apt-get update && apt-get install -y wget && \
-    wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 && \
-    chmod +x /usr/bin/yq
-RUN mkdir -p /var/log/xroad-metrics/opendata_collector/logs
+# =============================================================================
+# Base Stage - Common setup for all X-Road Metrics modules
+# =============================================================================
+FROM python:3.8-slim AS metrics-base
+
+ARG YQ_VERSION=4.43.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --system --group --no-create-home xroad-metrics
+
 COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /app/bin/xroad-metrics-opendata-collector
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /app
+
+# =============================================================================
+# Runtime Stage
+# =============================================================================
+FROM metrics-base AS runtime
+
+COPY opendata_collector_module/ ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip uninstall -y pip setuptools wheel \
+    && rm -rf /usr/local/lib/python*/site-packages/pip* \
+              /usr/local/lib/python*/site-packages/setuptools* \
+              /usr/local/lib/python*/site-packages/wheel* \
+    && find /usr/local/lib/python*/site-packages -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true \
+    && find /usr/local/lib/python*/site-packages -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
+
+RUN mkdir -p /var/log/xroad-metrics/opendata_collector/logs /var/run/xroad-metrics \
+    && ln -s /app/etc/settings.yaml /app/settings.yaml \
+    && chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics /var/run/xroad-metrics /app \
+    && chmod +x /app/bin/xroad-metrics-opendata-collector
+
+USER xroad-metrics
+
 ENTRYPOINT ["/entrypoint.sh", "/app/bin/xroad-metrics-opendata-collector"]

--- a/Docker/opendata_collector_module/Dockerfile
+++ b/Docker/opendata_collector_module/Dockerfile
@@ -1,29 +1,9 @@
-# =============================================================================
-# Base Stage - Common setup for all X-Road Metrics modules
-# =============================================================================
-FROM python:3.8-slim AS metrics-base
-
-ARG YQ_VERSION=4.43.1
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq \
-    && apt-get purge -y wget \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN adduser --system --group --no-create-home xroad-metrics
-
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-WORKDIR /app
+ARG BASE_IMAGE=set-via-prepare-containers.sh
 
 # =============================================================================
-# Runtime Stage
+# OpenData Collector Module
 # =============================================================================
-FROM metrics-base AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 COPY opendata_collector_module/ ./
 RUN pip install --no-cache-dir -r requirements.txt \

--- a/Docker/opendata_module/Dockerfile
+++ b/Docker/opendata_module/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN adduser --system --group --no-create-home xroad-metrics
+
 COPY Docker/docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
@@ -47,6 +49,9 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Add www-data to xroad-metrics group to access files through group membership
+RUN usermod -aG xroad-metrics www-data
+
 COPY --from=builder /wheels /wheels
 RUN pip install --no-cache-dir /wheels/* \
     && rm -rf /wheels \
@@ -65,7 +70,14 @@ RUN mkdir -p /var/log/xroad-metrics/opendata/logs /var/log/xroad-metrics/opendat
     && mkdir -p /etc/xroad-metrics/opendata \
     && cp /app/etc/field_data.yaml /etc/xroad-metrics/opendata/ \
     && ln -s /app/etc/settings.yaml /app/settings.yaml \
-    && chown -R www-data:www-data /var/log/xroad-metrics/opendata \
+    && chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics/opendata \
+                                            /var/run/xroad-metrics \
+                                            /app \
+                                            /etc/xroad-metrics/opendata \
+    && chmod -R g+rwx /var/log/xroad-metrics/opendata \
+                      /var/run/xroad-metrics \
+                      /app \
+                      /etc/xroad-metrics/opendata \
     && a2enmod wsgi
 
 ENV SKIP_LOG_REDIRECT=1

--- a/Docker/opendata_module/Dockerfile
+++ b/Docker/opendata_module/Dockerfile
@@ -1,25 +1,63 @@
-FROM python:3.11-slim-bookworm
-
-WORKDIR /app
+# =============================================================================
+# Builder Stage - Compile Python dependencies
+# =============================================================================
+FROM python:3.11-slim-bookworm AS builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \
-        wget \
-        apache2 \
-        libapache2-mod-wsgi-py3 \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY opendata_module/ ./
+RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
+
+# =============================================================================
+# Base Stage - Common setup for all X-Road Metrics modules
+# =============================================================================
+FROM python:3.11-slim-bookworm AS metrics-base
+
+ARG YQ_VERSION=4.43.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
     && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY opendata_module/ ./
-
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
-
 COPY Docker/docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /app
+
+# =============================================================================
+# Runtime Stage
+# =============================================================================
+FROM metrics-base AS runtime
+
+# Install runtime libraries for PostgreSQL and Apache
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq5 \
+        apache2 \
+        libapache2-mod-wsgi-py3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir /wheels/* \
+    && rm -rf /wheels \
+    && pip uninstall -y pip setuptools wheel \
+    && rm -rf /usr/local/lib/python*/site-packages/pip* \
+              /usr/local/lib/python*/site-packages/setuptools* \
+              /usr/local/lib/python*/site-packages/wheel* \
+    && find /usr/local/lib/python*/site-packages -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true \
+    && find /usr/local/lib/python*/site-packages -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
+
+COPY opendata_module/ ./
 COPY Docker/opendata_module/apache-opendata.conf /etc/apache2/sites-available/000-default.conf
 
 RUN mkdir -p /var/log/xroad-metrics/opendata/logs /var/log/xroad-metrics/opendata/heartbeat \
@@ -28,14 +66,11 @@ RUN mkdir -p /var/log/xroad-metrics/opendata/logs /var/log/xroad-metrics/opendat
     && cp /app/etc/field_data.yaml /etc/xroad-metrics/opendata/ \
     && ln -s /app/etc/settings.yaml /app/settings.yaml \
     && chown -R www-data:www-data /var/log/xroad-metrics/opendata \
-    && a2enmod wsgi \
-    && chmod +x /entrypoint.sh
+    && a2enmod wsgi
 
-# Skip log redirect to stdout - Apache WSGI runs as www-data and can't write to /dev/stdout symlinks
 ENV SKIP_LOG_REDIRECT=1
 
 EXPOSE 80
 
 ENTRYPOINT ["/entrypoint.sh"]
-# Set CMD to start Apache in foreground if no arguments are passed
 CMD ["apache2ctl", "-D", "FOREGROUND"]

--- a/Docker/opendata_module/Dockerfile
+++ b/Docker/opendata_module/Dockerfile
@@ -1,7 +1,9 @@
+ARG BASE_IMAGE=set-via-prepare-containers.sh
+
 # =============================================================================
 # Builder Stage - Compile Python dependencies
 # =============================================================================
-FROM python:3.11-slim-bookworm AS builder
+FROM ${BASE_IMAGE} AS builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -14,31 +16,9 @@ COPY opendata_module/ ./
 RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
 
 # =============================================================================
-# Base Stage - Common setup for all X-Road Metrics modules
+# OpenData Module
 # =============================================================================
-FROM python:3.11-slim-bookworm AS metrics-base
-
-ARG YQ_VERSION=4.43.1
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq \
-    && apt-get purge -y wget \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN adduser --system --group --no-create-home xroad-metrics
-
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-WORKDIR /app
-
-# =============================================================================
-# Runtime Stage
-# =============================================================================
-FROM metrics-base AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 # Install runtime libraries for PostgreSQL and Apache
 RUN apt-get update \
@@ -80,6 +60,7 @@ RUN mkdir -p /var/log/xroad-metrics/opendata/logs /var/log/xroad-metrics/opendat
                       /etc/xroad-metrics/opendata \
     && a2enmod wsgi
 
+# Skip log redirect to stdout - Apache WSGI runs as www-data and can't write to /dev/stdout symlinks
 ENV SKIP_LOG_REDIRECT=1
 
 EXPOSE 80

--- a/Docker/prepare-containers.sh
+++ b/Docker/prepare-containers.sh
@@ -1,60 +1,195 @@
 #!/bin/bash
 set -e
 
-MODULES=(collector_module corrector_module anonymizer_module opendata_module opendata_collector_module reports_module networking_module)
+# Change to project root directory.
+# Allows running by Docker/prepare-containers.sh or ./prepare-containers.sh
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd "$SCRIPT_DIR/.."
 
-# Networking base image not available for ARM. Limit networking_module to AMD64 only.
-AMD64_ONLY_MODULES=(networking_module)
+# =============================================================================
+# Output helpers (color output if terminal supports it)
+# =============================================================================
+IS_COLOR_ENABLED=$(command -v tput >/dev/null && tput setaf 1 &>/dev/null && echo true || echo false)
 
-usage() {
-  echo "Usage: $0 [module]"
-  echo "If no module is specified, all containers will be built."
-  echo "Available modules: ${MODULES[*]}"
+errorExit() {
+  echo ""
+  if $IS_COLOR_ENABLED; then
+    echo "$(tput setaf 5)*** $*$(tput sgr0)" 1>&2
+  else
+    echo "*** $*" 1>&2
+  fi
+  exit 1
 }
 
-build_module() {
-  local module=$1
-  local tag="xroad-metrics-${module//_/-}"
-  local dockerfile="Docker/${module}/Dockerfile"
-  local platform_flag=""
-  if [ ! -f "$dockerfile" ]; then
-    echo "Dockerfile for $module not found!"
-    exit 1
+warn() {
+  echo ""
+  if $IS_COLOR_ENABLED; then
+    echo "$(tput setaf 3)*** $*$(tput sgr0)"
+  else
+    echo "*** $*"
   fi
+  echo ""
+}
 
-  # Check if module requires amd64 platform
-  for amd64_module in "${AMD64_ONLY_MODULES[@]}"; do
-    if [ "$module" == "$amd64_module" ]; then
-      platform_flag="--platform=linux/amd64"
-      break
+success() {
+  echo ""
+  if $IS_COLOR_ENABLED; then
+    echo "$(tput setaf 2)*** $*$(tput sgr0)"
+  else
+    echo "*** $*"
+  fi
+  echo ""
+}
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Base image variants -> Python versions
+declare -A BASE_IMAGES=(
+  ["default"]="3.8-slim"
+  ["py311"]="3.11-slim-bookworm"
+)
+
+# Module configuration: "base_variant:platform"
+# - base_variant: default, py311, or empty (no base image)
+# - platform: default or amd64
+declare -A MODULES=(
+  ["collector_module"]="default:default"
+  ["corrector_module"]="default:default"
+  ["anonymizer_module"]="default:default"
+  ["opendata_collector_module"]="default:default"
+  ["reports_module"]="default:default"
+  ["opendata_module"]="py311:default"
+  ["networking_module"]=":amd64"
+)
+
+# =============================================================================
+# Validation
+# =============================================================================
+check_module_exists() {
+  local module=$1
+  if [[ ! -v "MODULES[$module]" ]]; then
+    usage
+    errorExit "Unknown module: $module"
+  fi
+}
+
+# =============================================================================
+# Config parsing
+# =============================================================================
+parse_module_config() {
+  local module=$1
+  IFS=':' read -r BASE_VARIANT PLATFORM <<< "${MODULES[$module]}"
+}
+
+get_required_base_versions() {
+  REQUIRED_BASE_VERSIONS=()
+  for module in "$@"; do
+    parse_module_config "$module"
+    if [[ -n "$BASE_VARIANT" ]]; then
+      local python_version="${BASE_IMAGES[$BASE_VARIANT]}"
+      # Check if already in array (simple approach, fine for 2-3 versions)
+      if [[ ! " ${REQUIRED_BASE_VERSIONS[*]} " =~ " ${python_version} " ]]; then
+        REQUIRED_BASE_VERSIONS+=("$python_version")
+      fi
     fi
   done
-
-  echo "Building $tag from $dockerfile ..."
-  docker build $platform_flag -t "$tag" -f "$dockerfile" .
 }
 
-if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+# =============================================================================
+# Build functions
+# =============================================================================
+build_base_images() {
+  get_required_base_versions "$@"
+
+  if [[ ${#REQUIRED_BASE_VERSIONS[@]} -eq 0 ]]; then
+    warn "No base images needed"
+    return
+  fi
+
+  success "Building ${#REQUIRED_BASE_VERSIONS[@]} base image(s)..."
+
+  for python_version in "${REQUIRED_BASE_VERSIONS[@]}"; do
+    local tag="xroad-metrics-base:${python_version}"
+
+    success "Building base image ${tag}..."
+    docker build \
+      --build-arg PYTHON_VERSION="${python_version}" \
+      -t "${tag}" \
+      -f Docker/metrics-base/Dockerfile \
+      .
+  done
+
+  success "Base images built successfully"
+}
+
+build_module_image() {
+  local module=$1
+  local dockerfile="Docker/${module}/Dockerfile"
+  local tag="xroad-metrics-${module//_/-}"
+
+  if [[ ! -f "$dockerfile" ]]; then
+    errorExit "Dockerfile not found: $dockerfile"
+  fi
+
+  parse_module_config "$module"
+
+  local build_args=()
+
+  if [[ "$PLATFORM" == "amd64" ]]; then
+    build_args+=(--platform=linux/amd64)
+  fi
+
+  if [[ -n "$BASE_VARIANT" ]]; then
+    build_args+=(--build-arg "BASE_IMAGE=xroad-metrics-base:${BASE_IMAGES[$BASE_VARIANT]}")
+  fi
+
+  success "Building ${tag}..."
+  docker build "${build_args[@]}" -t "${tag}" -f "${dockerfile}" .
+}
+
+build_images() {
+  local modules=("$@")
+
+  build_base_images "${modules[@]}"
+
+  for module in "${modules[@]}"; do
+    build_module_image "$module"
+  done
+
+  success "Build complete!"
+}
+
+# =============================================================================
+# Usage/help
+# =============================================================================
+usage() {
+  echo "Usage: $0 [module1 module2 ...]"
+  echo "  If no module is specified, all containers will be built."
+  echo "  Available modules:"
+  for m in "${!MODULES[@]}"; do
+    echo "    - $m"
+  done
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
   usage
   exit 0
 fi
 
-if [ -n "$1" ]; then
-  found=0
-  for m in "${MODULES[@]}"; do
-    if [ "$1" == "$m" ]; then
-      build_module "$m"
-      found=1
-      break
-    fi
-  done
-  if [ $found -eq 0 ]; then
-    echo "Unknown module: $1"
-    usage
-    exit 1
-  fi
+# Validate module names before building anything
+for module in "$@"; do
+  check_module_exists "$module"
+done
+
+if [[ $# -eq 0 ]]; then
+  # Building images of all modules
+  build_images "${!MODULES[@]}"
 else
-  for m in "${MODULES[@]}"; do
-    build_module "$m"
-  done
+  # Building images of required modules only
+  build_images "$@"
 fi

--- a/Docker/prepare-containers.sh
+++ b/Docker/prepare-containers.sh
@@ -3,11 +3,37 @@ set -e
 
 # Change to project root directory.
 # Allows running by Docker/prepare-containers.sh or ./prepare-containers.sh
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
 cd "$SCRIPT_DIR/.."
 
 # =============================================================================
-# Output helpers (color output if terminal supports it)
+# Configuration
+# =============================================================================
+
+# All available modules
+MODULES=(
+  collector_module
+  corrector_module
+  anonymizer_module
+  opendata_collector_module
+  reports_module
+  opendata_module
+  networking_module
+)
+
+# Modules that require amd64 platform
+AMD64_ONLY_MODULES=(networking_module)
+
+get_base_image() {
+  case "$1" in
+    opendata_module)   echo "3.11-slim-bookworm" ;;
+    networking_module) ;;
+    *)                 echo "3.8-slim" ;;
+  esac
+}
+
+# =============================================================================
+# Loggers
 # =============================================================================
 IS_COLOR_ENABLED=$(command -v tput >/dev/null && tput setaf 1 &>/dev/null && echo true || echo false)
 
@@ -42,56 +68,27 @@ success() {
 }
 
 # =============================================================================
-# Configuration
-# =============================================================================
-
-# Base image variants -> Python versions
-declare -A BASE_IMAGES=(
-  ["default"]="3.8-slim"
-  ["py311"]="3.11-slim-bookworm"
-)
-
-# Module configuration: "base_variant:platform"
-# - base_variant: default, py311, or empty (no base image)
-# - platform: default or amd64
-declare -A MODULES=(
-  ["collector_module"]="default:default"
-  ["corrector_module"]="default:default"
-  ["anonymizer_module"]="default:default"
-  ["opendata_collector_module"]="default:default"
-  ["reports_module"]="default:default"
-  ["opendata_module"]="py311:default"
-  ["networking_module"]=":amd64"
-)
-
-# =============================================================================
-# Validation
+# Helpers
 # =============================================================================
 check_module_exists() {
   local module=$1
-  if [[ ! -v "MODULES[$module]" ]]; then
-    usage
-    errorExit "Unknown module: $module"
-  fi
-}
-
-# =============================================================================
-# Config parsing
-# =============================================================================
-parse_module_config() {
-  local module=$1
-  IFS=':' read -r BASE_VARIANT PLATFORM <<< "${MODULES[$module]}"
+  for valid_module in "${MODULES[@]}"; do
+    if [ "$module" == "$valid_module" ]; then
+      return 0
+    fi
+  done
+  usage
+  errorExit "Unknown module: $module"
 }
 
 get_required_base_versions() {
   REQUIRED_BASE_VERSIONS=()
   for module in "$@"; do
-    parse_module_config "$module"
-    if [[ -n "$BASE_VARIANT" ]]; then
-      local python_version="${BASE_IMAGES[$BASE_VARIANT]}"
+    local base_image=$(get_base_image "$module")
+    if [[ -n "$base_image" ]]; then
       # Check if already in array (simple approach, fine for 2-3 versions)
-      if [[ ! " ${REQUIRED_BASE_VERSIONS[*]} " =~ " ${python_version} " ]]; then
-        REQUIRED_BASE_VERSIONS+=("$python_version")
+      if [[ ! " ${REQUIRED_BASE_VERSIONS[*]} " =~ " ${base_image} " ]]; then
+        REQUIRED_BASE_VERSIONS+=("$base_image")
       fi
     fi
   done
@@ -133,16 +130,18 @@ build_module_image() {
     errorExit "Dockerfile not found: $dockerfile"
   fi
 
-  parse_module_config "$module"
-
   local build_args=()
 
-  if [[ "$PLATFORM" == "amd64" ]]; then
-    build_args+=(--platform=linux/amd64)
-  fi
+  for amd64_module in "${AMD64_ONLY_MODULES[@]}"; do
+    if [ "$module" == "$amd64_module" ]; then
+      build_args+=(--platform=linux/amd64)
+      break
+    fi
+  done
 
-  if [[ -n "$BASE_VARIANT" ]]; then
-    build_args+=(--build-arg "BASE_IMAGE=xroad-metrics-base:${BASE_IMAGES[$BASE_VARIANT]}")
+  local base_image=$(get_base_image "$module")
+  if [[ -n "$base_image" ]]; then
+    build_args+=(--build-arg "BASE_IMAGE=xroad-metrics-base:${base_image}")
   fi
 
   success "Building ${tag}..."
@@ -168,7 +167,7 @@ usage() {
   echo "Usage: $0 [module1 module2 ...]"
   echo "  If no module is specified, all containers will be built."
   echo "  Available modules:"
-  for m in "${!MODULES[@]}"; do
+  for m in "${MODULES[@]}"; do
     echo "    - $m"
   done
 }
@@ -188,7 +187,7 @@ done
 
 if [[ $# -eq 0 ]]; then
   # Building images of all modules
-  build_images "${!MODULES[@]}"
+  build_images "${MODULES[@]}"
 else
   # Building images of required modules only
   build_images "$@"

--- a/Docker/reports_module/Dockerfile
+++ b/Docker/reports_module/Dockerfile
@@ -1,40 +1,62 @@
-FROM python:3.8-slim
+# =============================================================================
+# Base Stage - Common setup for all X-Road Metrics modules
+# =============================================================================
+FROM python:3.8-slim AS metrics-base
+
+ARG YQ_VERSION=4.43.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
+    && chmod +x /usr/bin/yq \
+    && apt-get purge -y wget \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --system --group --no-create-home xroad-metrics
+
+COPY Docker/docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 WORKDIR /app
 
+# =============================================================================
+# Runtime Stage
+# =============================================================================
+FROM metrics-base AS runtime
+
+# Install runtime dependencies for PDF rendering
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        wget \
         libpango-1.0-0 \
         libgdk-pixbuf-2.0-0 \
-        libffi-dev \
+        libffi8 \
         libcairo2 \
         libxml2 \
         libxslt1.1 \
         fonts-liberation \
         fonts-dejavu-core \
         libpangoft2-1.0-0 \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY reports_module/ ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip uninstall -y pip setuptools wheel \
+    && rm -rf /usr/local/lib/python*/site-packages/pip* \
+              /usr/local/lib/python*/site-packages/setuptools* \
+              /usr/local/lib/python*/site-packages/wheel* \
+    && find /usr/local/lib/python*/site-packages -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true \
+    && find /usr/local/lib/python*/site-packages -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
-
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-
-RUN adduser --system --group --no-create-home xroad-metrics \
-    && mkdir -p /var/log/xroad-metrics/reports/logs /var/run/xroad-metrics \
+RUN mkdir -p /var/log/xroad-metrics/reports/logs /var/run/xroad-metrics \
     && mkdir -p /etc/xroad-metrics/reports /var/lib/xroad-metrics/reports \
     && cp -r /app/etc/lang /etc/xroad-metrics/reports/ \
     && cp -r /app/etc/template /etc/xroad-metrics/reports/ \
     && ln -s /app/etc/settings.yaml /app/settings.yaml \
-    && chown -R xroad-metrics:xroad-metrics /app /var/log/xroad-metrics /var/run/xroad-metrics \
-       /etc/xroad-metrics/reports /var/lib/xroad-metrics/reports \
-    && chmod +x /app/bin/xroad-metrics-reports /entrypoint.sh
+    && chown -R xroad-metrics:xroad-metrics /var/log/xroad-metrics /var/run/xroad-metrics \
+       /etc/xroad-metrics/reports /var/lib/xroad-metrics/reports /app \
+    && chmod +x /app/bin/xroad-metrics-reports
 
 USER xroad-metrics
 

--- a/Docker/reports_module/Dockerfile
+++ b/Docker/reports_module/Dockerfile
@@ -1,29 +1,9 @@
-# =============================================================================
-# Base Stage - Common setup for all X-Road Metrics modules
-# =============================================================================
-FROM python:3.8-slim AS metrics-base
-
-ARG YQ_VERSION=4.43.1
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 \
-    && chmod +x /usr/bin/yq \
-    && apt-get purge -y wget \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN adduser --system --group --no-create-home xroad-metrics
-
-COPY Docker/docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-WORKDIR /app
+ARG BASE_IMAGE=set-via-prepare-containers.sh
 
 # =============================================================================
-# Runtime Stage
+# Reports Module
 # =============================================================================
-FROM metrics-base AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 # Install runtime dependencies for PDF rendering
 RUN apt-get update \


### PR DESCRIPTION
  - Add .dockerignore to reduce build context
  - Implement metrics-base stage for consistency across modules
  - Add builder stage for anonymizer/opendata (removes build-essential)
  - Remove pip/setuptools/wheel after install
  - Updates networking module to rocker/shiny:4.5.2


**Size Comparison before and after optimizations:**

| Module             | Original | Final  | Change |
| ------------------ | -------- | ------ | ------ |
| collector          | 227MB    | 153MB  | -33%   |
| corrector          | 230MB    | 150MB  | -35%   |
| opendata_collector | 233MB    | 153MB  | -34%   |
| anonymizer         | 542MB    | 158MB  | -71%   |
| opendata           | 643MB    | 353MB  | -45%   |
| reports            | 601MB    | 414MB  | -31%   |
| networking         | 1.72GB   | 1.83GB | +6%*   |
