### PR TITLE
feat: Create users on PostgreSQL 15+ with necessary schema privileges

### DIFF
--- a/docs/opendata_module.md
+++ b/docs/opendata_module.md
@@ -129,18 +129,6 @@ sudo apt install postgresql
 
 ### Automatic PostgreSQL User Creation
 
-> [!IMPORTANT]
-> For automatic users creation to work properly, PostgreSQL version must be 14 or less.  
-> Starting from PostgreSQL 15, ownership of `public` schema has changed to the new `pg_database_owner` role. 
-> Due to this change, the command will create users but without proper permissions to create tables in the database's
-> public schema. In this case, after creating users with the below script, connect to the database, and grant `create`
-> and `usage` permissions on `public` schema to user `anonymizer_ex` using the following SQL statement:
-> ```sql
-> GRANT CREATE, USAGE ON SCHEMA public TO anonymizer_ex;
-> ```
-> 
-> For more information, see [PostgreSQL 15 Release Notes - Migration](https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.18.4).
-
 The X-Road Metrics Opendata package includes a command that creates the PostgreSQL users automatically.
 To create PostgreSQL users for X-Road instance *LTT* on `localhost` run the following commands:
 

--- a/opendata_module/opmon_postgresql_maintenance/create_users.py
+++ b/opendata_module/opmon_postgresql_maintenance/create_users.py
@@ -218,7 +218,11 @@ def _grant_schema_privileges(args: argparse.Namespace) -> None:
         cursor = db_conn.cursor()
         for user_prefix in full_users:
             user = f'{user_prefix}_{args.xroad}'
-            cursor.execute(f'GRANT CREATE, USAGE ON SCHEMA public TO {user};')
+            try:
+                cursor.execute(f'GRANT CREATE, USAGE ON SCHEMA public TO {user};')
+                logger.info(f'Schema privileges granted successfully to user {user}')
+            except psycopg2.Error as e:
+                logger.error(f'Failed to grant schema privileges to user {user}: {e}')
     finally:
         db_conn.close()
 

--- a/opendata_module/opmon_postgresql_maintenance/create_users.py
+++ b/opendata_module/opmon_postgresql_maintenance/create_users.py
@@ -76,6 +76,10 @@ def main():
     except psycopg2_errors.DuplicateObject as e:
         logger.info(str(e))
 
+    # Grant schema-level privileges after users are committed
+    # (required for PostgreSQL 15+ where public schema no longer grants CREATE to PUBLIC)
+    _grant_schema_privileges(args)
+
 
 def _remove_users(args: argparse.Namespace,
                   postgres_conn: psycopg2.extensions.connection) -> None:
@@ -112,15 +116,16 @@ def _remove_users(args: argparse.Namespace,
             logger.info(f'Trying to remove read only {user}: {str(e)}')
 
 
-def _connect_postgres(args: argparse.Namespace) -> psycopg2.extensions.connection:
+def _connect_postgres(args: argparse.Namespace, database: str = '') -> psycopg2.extensions.connection:
     """
     Establishes a connection to the PostgreSQL database.
 
     :param args: Arguments passed to the function.
+    :param database: Database name to connect to. Empty string for default.
     :return: A psycopg2 connection object.
     """
     connections_args = {
-        'database': '',
+        'database': database,
         'user': args.user,
     }
 
@@ -193,6 +198,29 @@ def _grant_privileges(args: argparse.Namespace,
     for user_prefix in read_only_users:
         user = f'{user_prefix}_{args.xroad}'
         postgres_conn.cursor().execute(f'GRANT CONNECT ON DATABASE {database} TO {user} WITH GRANT OPTION;')
+
+
+def _grant_schema_privileges(args: argparse.Namespace) -> None:
+    """
+    Grants schema-level privileges to full users.
+
+    In PostgreSQL 15+, the public schema no longer grants CREATE privilege to PUBLIC
+    by default. This function connects to the target database and grants the necessary
+    schema privileges to allow table creation.
+
+    :param args: Arguments passed to the function.
+    """
+    database = f'opendata_{args.xroad}'
+    db_conn = _connect_postgres(args, database)
+    db_conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+
+    try:
+        cursor = db_conn.cursor()
+        for user_prefix in full_users:
+            user = f'{user_prefix}_{args.xroad}'
+            cursor.execute(f'GRANT CREATE, USAGE ON SCHEMA public TO {user};')
+    finally:
+        db_conn.close()
 
 
 def _parse_args():


### PR DESCRIPTION
This PR fixes the issue of auto-creating users on PostgreSQL 15+.

Starting from PostgreSQL 15, ownership of `public` schema has changed to the new `pg_database_owner` role. 
This PR modifies the `create_users.py` to  grant required permissions for the `anonymizer` user to be able to create tables on database's `public` schema.

I verified the fix by using the following setup:
- Installed `opendata` and `anonymizer` modules on 1 LXD container
- Installed Postgres 18 locally to the same LXD container
- Created users via `opendata` module
- Ran `anonymizer` module using the newly anonymizer's user
- Verified the `logs` table was created without issues.